### PR TITLE
Add sign up page and improve validation support

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -74,13 +74,14 @@ const svelteFiles = {
 	routes: [
 		{
 			path: FRONTEND_ROUTES_DIR,
-			templates: ['_error.svelte', '_layout.svelte', 'index.svelte', 'login.svelte'],
+			templates: ['_error.svelte', '_layout.svelte', 'index.svelte', 'login.svelte', 'account/register.svelte'],
 		},
 	],
 	components: [
 		{
 			path: FRONTEND_COMPONENTS_DIR,
 			templates: [
+				'account/account-service.js',
 				'Alert.svelte',
 				'InputControl.svelte',
 				'auth/auth-service.js',

--- a/generators/client/templates/svelte/src/main/webapp/app/components/Alert.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/Alert.svelte.ejs
@@ -1,6 +1,7 @@
 <script>
 	export let show = false
 	export let type = 'success'
+	export let closeable = true
 
 	function closeAlert() {
 		show = false
@@ -9,6 +10,8 @@
 
 <div
 	class:hidden="{!show}"
+	class:bg-green-200="{type === 'success'}"
+	class:text-green-900="{type === 'success'}"
 	class:bg-red-200="{type === 'danger'}"
 	class:text-red-900="{type === 'danger'}"
 	class="px-7 py-3 mt-4 flex justify-between rounded text-sm"
@@ -16,10 +19,12 @@
 	<div>
 		<slot />
 	</div>
-	<button
-		class:hover:text-red-700="{type === 'danger'}"
-		class="self-start text-xl leading-4 bg-transparent border-0
-			focus:outline-none"
-		on:click="{closeAlert}"
-	>&times</button>
+	{#if closeable}
+		<button
+			class:hover:text-red-700="{type === 'danger'}"
+			class="self-start text-xl leading-4 bg-transparent border-0
+				focus:outline-none"
+			on:click="{closeAlert}"
+		>&times</button>
+	{/if}
 </div>

--- a/generators/client/templates/svelte/src/main/webapp/app/components/InputControl.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/InputControl.svelte.ejs
@@ -75,13 +75,14 @@
 	/>
 </div>
 <div class="flex flex-col mt-1 px-3 text-xs text-red-600">
-	{#if dirty && !valid}
-		<slot>
-			<div class="flex items-center" >
-				<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />{message}
+	<slot {message} {dirty} {valid}>
+		{#if dirty && !valid}
+			<div class="flex items-center">
+				<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />
+				{message}
 			</div>
-		</slot>
-	{:else}
-		&nbsp;
-	{/if}
+		{:else}
+			&nbsp;
+		{/if}
+	</slot>
 </div>

--- a/generators/client/templates/svelte/src/main/webapp/app/components/account/account-service.js.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/account/account-service.js.ejs
@@ -1,0 +1,29 @@
+import { serverUrl } from '../../utils/env'
+import { prepareRequest } from '../../utils/request'
+
+export default {
+	createAccount: (username, email, password) => {
+		const body = JSON.stringify({
+			login: username,
+			email,
+			password,
+			langKey: 'en',
+		})
+
+		return fetch(
+			`${serverUrl}api/register`,
+			prepareRequest('POST', body, {
+				'Content-Type': 'application/json',
+			})
+		)
+			.then(response => {
+				if (response.ok) {
+					return Promise.resolve()
+				}
+				return response.json().then(Promise.reject.bind(Promise))
+			})
+			.catch(err => {
+				return Promise.reject(err)
+			})
+	},
+}

--- a/generators/client/templates/svelte/src/main/webapp/app/components/layout/Navbar.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/layout/Navbar.svelte.ejs
@@ -60,7 +60,7 @@
 					on:click="{toggleToolbar}"
 					label="Sign up"
 					icon="{faUserPlus}"
-					route="/register"
+					route="/account/register"
 				/>
 			</div>
 		{/if}

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/account/register.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/account/register.svelte.ejs
@@ -1,0 +1,156 @@
+<script>
+	import Icon from 'fa-svelte'
+	import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle'
+
+	import Alert from './../../components/Alert.svelte'
+	import InputControl from '../../components/InputControl.svelte'
+	import accountService from './../../components/account/account-service'
+	import { problemBaseUrl } from './../../utils/env'
+
+	let username
+	let email
+	let password
+	let confirmPassword
+	let validUsername = false
+	let validEmail = false
+	let validPassword = false
+	let validConfirmPassword = false
+
+	let error
+	let accountCreated = false
+
+	$: validForm = validUsername && validEmail && validPassword && validConfirmPassword && !confirmPasswordMismatch
+	$: confirmPasswordMismatch = validConfirmPassword && password !== confirmPassword
+
+	function createUserAccount() {
+		error = undefined
+		accountCreated = false
+		accountService
+			.createAccount(username, email, password)
+			.then(() => accountCreated = true)
+			.catch((err) => {
+				password = ''
+				confirmPassword = ''
+				if(err && err.type) {
+					if(err.type === (problemBaseUrl + '/email-already-used')) {
+						error = 'duplicateEmail'
+					} else if(err.type === (problemBaseUrl + '/login-already-used')) {
+						error = 'duplicateLogin'
+					} else {
+						error = 'error';
+					}
+				} else {
+					error = 'error'
+				}
+			})
+	}
+
+</script>
+
+<svelte:head>
+	<title>Create user account</title>
+</svelte:head>
+
+<section class="m-3 relative bg-white shadow-md rounded p-4">
+	<div class="p-4 w-full sm:max-w-3xl sm:mx-auto">
+		<div class="px-4 w-full text-4xl text-center">
+			Create user account
+		</div>
+		<Alert show="{accountCreated}" closeable="{false}">
+			User account successfully created. Please check your email for confirmation.
+		</Alert>
+		<Alert type="danger" show="{!!error}">
+			{#if error === 'duplicateEmail'}
+			Email is already in use. Please choose another one.
+			{:else if error === 'duplicateLogin'}
+			Login name already in use. Please choose another one.
+			{:else if error}
+			User account creation failed. Please try again later.
+			{/if}
+		</Alert>
+		{#if !accountCreated}
+			<form class="mt-4 flex flex-col">
+				<InputControl
+					label="Username"
+					name="username"
+					value="{username}"
+					on:input="{event => (username = event.target.value)}"
+					required
+					validations="{[
+						{ type: 'required', message: 'Username is mandatory' },
+						{ type: 'maxlength', maxlength: 50, message: 'Username cannot be longer than 50 characters' },
+						{ type: 'pattern', pattern: /^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$|^[_.@A-Za-z0-9-]+$/, message: 'Username can only contain letters and digits' }
+						]}"
+					on:validate="{event => (validUsername = event.detail.valid)}"
+				/>
+				<InputControl
+					type="email"
+					label="Email"
+					name="email"
+					value="{email}"
+					on:input="{event => (email = event.target.value)}"
+					required
+					validations="{[
+						{ type: 'required', message: 'Email is mandatory' },
+						{ type: 'minlength', minlength: 5, message: 'Email is required to be at least 5 characters' },
+						{ type: 'maxlength', maxlength: 254, message: 'Email cannot be longer than 254 characters' },
+						{ type: 'pattern',
+						pattern: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/, message: 'Email address is not valid' }
+						]}"
+					on:validate="{event => (validEmail = event.detail.valid)}"
+				/>
+
+				<InputControl
+					type="password"
+					label="Password"
+					name="password"
+					value="{password}"
+					on:input="{event => (password = event.target.value)}"
+					required
+					validations="{[
+						{ type: 'required', message: 'Password is mandatory' },
+						{ type: 'minlength', minlength: 4, message: 'Password is required to be at least 4 characters' },
+						{ type: 'maxlength', maxlength: 50, message: 'Password cannot be longer than 50 characters' }
+						]}"
+					on:validate="{event => (validPassword = event.detail.valid)}"
+				/>
+				<InputControl
+					type="password"
+					label="Confirm Password"
+					name="confirmPassword"
+					value="{confirmPassword}"
+					on:input="{event => (confirmPassword = event.target.value)}"
+					required
+					validations="{[
+						{ type: 'required', message: 'Password is mandatory' },
+						{ type: 'minlength', minlength: 4, message: 'Password is required to be at least 4 characters' },
+						{ type: 'maxlength', maxlength: 50, message: 'Password cannot be longer than 50 characters' }
+						]}"
+					on:validate="{event => (validConfirmPassword = event.detail.valid)}"
+					let:message={message}
+					let:dirty={dirty}
+					let:valid={valid}
+				>
+				<div class="flex items-center">
+					{#if confirmPasswordMismatch}
+						<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />
+						Password and its confirmation do not match
+					{:else if dirty && !valid}
+						<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />
+						{message}
+					{:else}
+						&nbsp;
+					{/if}
+				</div>
+			</InputControl>
+
+				<button
+					type="submit"
+					on:click|preventDefault="{createUserAccount}"
+					class="my-4 w-48 m-auto btn btn-primary"
+					disabled="{!validForm}"
+				>Create account</button>
+			</form>
+		{/if}
+	</div>
+</section>

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/index.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/index.svelte.ejs
@@ -46,7 +46,7 @@
 					>
 						<span>You don't have an account yet?</span>&nbsp; <a
 							class="font-semibold"
-							href="/register"
+							href="/account/register"
 						>Register a new account</a>
 					</div>
 				{/if}

--- a/generators/client/templates/svelte/src/main/webapp/app/utils/env.js.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/utils/env.js.ejs
@@ -1,1 +1,2 @@
 export const serverUrl = 'http://localhost:8080/'
+export const problemBaseUrl = 'https://www.jhipster.tech/problem'

--- a/generators/client/templates/svelte/src/main/webapp/app/utils/validator.js.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/utils/validator.js.ejs
@@ -32,6 +32,10 @@ function createValidator(validations) {
 					return required(validationArgs)
 				case 'minlength':
 					return minlength(validationArgs)
+				case 'maxlength':
+					return maxlength(validationArgs)
+				case 'pattern':
+					return pattern(validationArgs)
 				default:
 					throw new Error(`Invalid validation type ${type}`)
 			}
@@ -47,7 +51,7 @@ function createValidator(validations) {
 
 function required(validationArgs) {
 	const { message } = validationArgs
-	return function required(value) {
+	return function (value) {
 		if (value === undefined || value === null || value.trim() === '') {
 			return message || 'This field is required'
 		}
@@ -55,13 +59,35 @@ function required(validationArgs) {
 }
 
 function minlength(validationArgs) {
-	const { message, min } = validationArgs
-	return function minlength(value) {
-		if (value.trim().length < min) {
+	const { message, minlength } = validationArgs
+	return function (value) {
+		if (value.trim().length < minlength) {
 			return (
 				message ||
-				`The field value should be greater than ${min} characters`
+				`The field value should be greater than ${minlength} characters`
 			)
 		}
 	}
 }
+
+function maxlength(validationArgs) {
+	const { message, maxlength } = validationArgs
+	return function (value) {
+		if (value.trim().length > maxlength) {
+			return (
+				message ||
+				`The field value should be less than ${maxlength} characters`
+			)
+		}
+	}
+}
+
+function pattern(validationArgs) {
+	const { message, pattern } = validationArgs
+	return function (value) {
+		if (!pattern.test(value.trim())) {
+			return message || `The field value should match the pattern`
+		}
+	}
+}
+


### PR DESCRIPTION
Closes #18 
---

- Add `sign-up` page along with relevant backend API integration
- Add new `closeable` property in the `Alert` component and success theme layout
- Expose `message`, `dirty` and `valid` properties in `InputControl` component to be available to caller component
- Support `maxlength` and `pattern` validations
 