### PR TITLE
Extract password confirm component

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -90,6 +90,7 @@ const svelteFiles = {
 			path: FRONTEND_COMPONENTS_DIR,
 			templates: [
 				'account/account-service.js',
+				'account/PasswordConfirm.svelte',
 				'Alert.svelte',
 				'InputControl.svelte',
 				'auth/auth-service.js',

--- a/generators/client/templates/svelte/src/main/webapp/app/components/account/PasswordConfirm.svelte
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/account/PasswordConfirm.svelte
@@ -1,0 +1,77 @@
+<script>
+	import { createEventDispatcher } from 'svelte'
+	import Icon from 'fa-svelte'
+	import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle'
+
+	import InputControl from '../InputControl.svelte'
+
+	export let label='Password';
+	export let value = '';
+	const dispatch = createEventDispatcher()
+
+	let confirmPassword
+
+	let validPassword = false
+	let validConfirmPassword = false
+
+	$: confirmPasswordMismatch =
+		validConfirmPassword && value !== confirmPassword
+
+	function handlePassword(event) {
+		value = event.target.value
+		dispatch('input', {value})
+	}
+
+	function handlePasswordValidation(event) {
+		validPassword = event.detail.valid
+		dispatch('validate', {'valid' : isValid()})
+	}
+
+	function handleConfirmPasswordValidation(event) {
+		validConfirmPassword = event.detail.valid
+		dispatch('validate', {'valid' : isValid()})
+	}
+	function isValid() {
+		return validPassword && validConfirmPassword && value === confirmPassword;
+	}
+</script>
+
+<InputControl
+	type="password"
+	label="{label}"
+	name="password"
+	value="{value}"
+	on:input="{handlePassword}"
+	required
+	validations="{[{ type: 'required', message: 'Password is mandatory' }, { type: 'minlength', minlength: 4, message: 'Password is required to be at least 4 characters' }, { type: 'maxlength', maxlength: 50, message: 'Password cannot be longer than 50 characters' }]}"
+	on:validate="{handlePasswordValidation}"
+/>
+<InputControl
+	type="password"
+	label="Confirm Password"
+	name="confirmPassword"
+	value="{confirmPassword}"
+	on:input="{event => (confirmPassword = event.target.value)}"
+	required
+	validations="{[{ type: 'required', message: 'Password is mandatory' }, { type: 'minlength', minlength: 4, message: 'Password is required to be at least 4 characters' }, { type: 'maxlength', maxlength: 50, message: 'Password cannot be longer than 50 characters' }]}"
+	on:validate="{handleConfirmPasswordValidation}"
+	let:message
+	let:dirty
+	let:valid
+>
+	<div class="flex items-center">
+		{#if confirmPasswordMismatch}
+			<Icon
+				class="fa-icon mr-2"
+				icon="{faExclamationCircle}"
+			/>
+			Password and its confirmation do not match
+		{:else if dirty && !valid}
+			<Icon
+				class="fa-icon mr-2"
+				icon="{faExclamationCircle}"
+			/>
+			{message}
+		{:else}&nbsp;{/if}
+	</div>
+</InputControl>

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/account/register.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/account/register.svelte.ejs
@@ -1,26 +1,21 @@
 <script>
-	import Icon from 'fa-svelte'
-	import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle'
-
 	import Alert from './../../components/Alert.svelte'
 	import InputControl from '../../components/InputControl.svelte'
 	import accountService from './../../components/account/account-service'
+	import PasswordConfirm from './../../components/account/PasswordConfirm.svelte'
 	import { problemBaseUrl } from './../../utils/env'
 
 	let username
 	let email
 	let password
-	let confirmPassword
 	let validUsername = false
 	let validEmail = false
 	let validPassword = false
-	let validConfirmPassword = false
 
 	let error
 	let accountCreated = false
 
-	$: validForm = validUsername && validEmail && validPassword && validConfirmPassword && !confirmPasswordMismatch
-	$: confirmPasswordMismatch = validConfirmPassword && password !== confirmPassword
+	$: validForm = validUsername && validEmail && validPassword
 
 	function createUserAccount() {
 		error = undefined
@@ -30,7 +25,6 @@
 			.then(() => accountCreated = true)
 			.catch((err) => {
 				password = ''
-				confirmPassword = ''
 				if(err && err.type) {
 					if(err.type === (problemBaseUrl + '/email-already-used')) {
 						error = 'duplicateEmail'
@@ -100,49 +94,12 @@
 					on:validate="{event => (validEmail = event.detail.valid)}"
 				/>
 
-				<InputControl
-					type="password"
+				<PasswordConfirm
 					label="Password"
-					name="password"
 					value="{password}"
-					on:input="{event => (password = event.target.value)}"
-					required
-					validations="{[
-						{ type: 'required', message: 'Password is mandatory' },
-						{ type: 'minlength', minlength: 4, message: 'Password is required to be at least 4 characters' },
-						{ type: 'maxlength', maxlength: 50, message: 'Password cannot be longer than 50 characters' }
-						]}"
+					on:input={event => password = event.detail.value}
 					on:validate="{event => (validPassword = event.detail.valid)}"
 				/>
-				<InputControl
-					type="password"
-					label="Confirm Password"
-					name="confirmPassword"
-					value="{confirmPassword}"
-					on:input="{event => (confirmPassword = event.target.value)}"
-					required
-					validations="{[
-						{ type: 'required', message: 'Password is mandatory' },
-						{ type: 'minlength', minlength: 4, message: 'Password is required to be at least 4 characters' },
-						{ type: 'maxlength', maxlength: 50, message: 'Password cannot be longer than 50 characters' }
-						]}"
-					on:validate="{event => (validConfirmPassword = event.detail.valid)}"
-					let:message={message}
-					let:dirty={dirty}
-					let:valid={valid}
-				>
-				<div class="flex items-center">
-					{#if confirmPasswordMismatch}
-						<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />
-						Password and its confirmation do not match
-					{:else if dirty && !valid}
-						<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />
-						{message}
-					{:else}
-						&nbsp;
-					{/if}
-				</div>
-			</InputControl>
 
 				<button
 					type="submit"


### PR DESCRIPTION
Extract `password` and `confirm password` controls from the `register` page into a separate `PasswordConfirm` component to reuse that in `register`, `password reset` and `change password` pages.