### PR TITLE
Generate Cypress e2e tests for login and settings screens

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -30,6 +30,7 @@ const svelteFiles = {
 			templates: [
 				'cypress/integration/home.spec.js',
 				'cypress/integration/login.spec.js',
+				'cypress/integration/account/settings.spec.js',
 				'cypress/plugins/index.js',
 				'cypress/support/index.js',
 				'cypress/support/commands.js',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -25,11 +25,11 @@ const svelteFiles = {
 			],
 		},
 	],
-	tests: [
+	e2e: [
 		{
 			templates: [
-				'cypress/fixtures/example.json',
-				'cypress/integration/spec.js',
+				'cypress/integration/home.spec.js',
+				'cypress/integration/login.spec.js',
 				'cypress/plugins/index.js',
 				'cypress/support/index.js',
 				'cypress/support/commands.js',

--- a/generators/client/templates/svelte/.eslintrc.json.ejs
+++ b/generators/client/templates/svelte/.eslintrc.json.ejs
@@ -1,5 +1,5 @@
 {
-	"extends": ["eslint:recommended"],
+	"extends": ["eslint:recommended", "plugin:cypress/recommended"],
 	"parserOptions": {
 		"ecmaVersion": 2019,
 		"sourceType": "module"
@@ -7,9 +7,10 @@
 	"env": {
 		"es6": true,
 		"browser": true,
-		"node": true
+		"node": true,
+		"cypress/globals": true
 	},
-	"plugins": ["svelte3"],
+	"plugins": ["svelte3", "cypress"],
 	"overrides": [
 		{
 			"files": ["**/*.svelte"],

--- a/generators/client/templates/svelte/cypress/fixtures/example.json.ejs
+++ b/generators/client/templates/svelte/cypress/fixtures/example.json.ejs
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/generators/client/templates/svelte/cypress/integration/account/settings.spec.js.ejs
+++ b/generators/client/templates/svelte/cypress/integration/account/settings.spec.js.ejs
@@ -1,0 +1,92 @@
+describe('User Settings', () => {
+	beforeEach(() => {
+		cy.loginByApi('admin', 'admin')
+		cy.visit('/account/settings')
+	})
+
+	it('should greets with User Settings title', () => {
+		cy.getBySel('settingsTitle').should(
+			'have.text',
+			'User settings for [admin]'
+		)
+	})
+
+	it('should display current settings', () => {
+		cy.getBySel('settingsForm')
+			.getByName('firstName')
+			.invoke('val')
+			.then(val => {
+				expect(val).to.include('Admin')
+			})
+		cy.getBySel('settingsForm')
+			.getByName('lastName')
+			.invoke('val')
+			.then(val => {
+				expect(val).to.include('Admin')
+			})
+		cy.getBySel('settingsForm')
+			.getByName('email')
+			.invoke('val')
+			.then(val => {
+				expect(val).to.include('admin@localhost')
+			})
+	})
+
+	it('should display form control validation messages', () => {
+		cy.getBySel('settingsForm').getByName('firstName').clear().blur()
+		cy.getBySel('settingsForm')
+			.getBySel('firstName-error')
+			.should('be.visible')
+			.and('contain', 'First name is mandatory')
+
+		cy.getBySel('settingsForm').getByName('lastName').clear().blur()
+		cy.getBySel('settingsForm')
+			.getBySel('lastName-error')
+			.should('be.visible')
+			.and('contain', 'Last name is mandatory')
+
+		cy.getBySel('settingsForm').getByName('email').clear().blur()
+		cy.getBySel('settingsForm')
+			.getBySel('email-error')
+			.should('be.visible')
+			.and('contain', 'Email is mandatory')
+
+		cy.getBySel('settingsForm')
+			.getByName('email')
+			.type('admin@localhost')
+			.blur()
+		cy.getBySel('settingsForm')
+			.getBySel('email-error')
+			.should('be.visible')
+			.and('contain', 'Email address is not valid')
+
+		cy.getBySel('settingsForm')
+			.contains('Update Settings')
+			.should('be.disabled')
+	})
+
+	it('should update user settings', () => {
+		cy.getBySel('settingsForm')
+			.getByName('firstName')
+			.clear()
+			.type('Admin')
+			.blur()
+		cy.getBySel('settingsForm')
+			.getByName('lastName')
+			.clear()
+			.type('Admin')
+			.blur()
+		cy.getBySel('settingsForm')
+			.getByName('email')
+			.clear()
+			.type('admin@localhost.org')
+			.blur()
+
+		cy.getBySel('settingsForm')
+			.contains('Update Settings')
+			.should('not.be.disabled')
+			.click()
+
+		cy.getBySel('successMsg').contains('Settings changed!')
+	})
+})

--- a/generators/client/templates/svelte/cypress/integration/home.spec.js.ejs
+++ b/generators/client/templates/svelte/cypress/integration/home.spec.js.ejs
@@ -1,4 +1,4 @@
-describe('Sapper template app', () => {
+describe('Home page', () => {
 	beforeEach(() => {
 		cy.visit('/')
 	})

--- a/generators/client/templates/svelte/cypress/integration/login.spec.js.ejs
+++ b/generators/client/templates/svelte/cypress/integration/login.spec.js.ejs
@@ -1,0 +1,50 @@
+describe('login flow', () => {
+	beforeEach(() => {
+		cy.visit('/login')
+	})
+
+	it('greets with Sign in', () => {
+		cy.get('[data-cy="signInTitle"]')
+			.should('be.visible')
+			.should('contain', 'Sign in to SvelteHipster')
+	})
+
+	it('link to register', () => {
+		cy.get('[data-cy="registerLink"]')
+			.should('have.text', 'Create an account')
+			.should('have.attr', 'href', '/account/register')
+	})
+
+	it('link to forgot password', () => {
+		cy.get('[data-cy="forgotPwdLink"]')
+			.should('have.text', 'Forgot password?')
+			.should('have.attr', 'href', '/account/reset/init')
+	})
+
+	it('require username and password', () => {
+		cy.get('[data-cy="loginForm"]')
+			.contains('Sign in')
+			.should('be.disabled')
+	})
+
+	it('require valid username and password', () => {
+		cy.get('[data-cy="loginForm"]')
+			.get('[name="username"]')
+			.type('admin')
+			.get('[name="password"]')
+			.type('invalid{enter}')
+		cy.get('[data-cy="errorMsg"]').should(
+			'contain',
+			'Incorrect username or password.'
+		)
+	})
+
+	it('navigate to / on successful login', () => {
+		cy.get('[data-cy="loginForm"]')
+			.get('[name="username"]')
+			.type('admin')
+			.get('[name="password"]')
+			.type('admin{enter}')
+		cy.location('pathname').should('eq', '/')
+	})
+})

--- a/generators/client/templates/svelte/cypress/integration/login.spec.js.ejs
+++ b/generators/client/templates/svelte/cypress/integration/login.spec.js.ejs
@@ -1,49 +1,71 @@
-describe('login flow', () => {
+describe('User login', () => {
 	beforeEach(() => {
 		cy.visit('/login')
 	})
 
-	it('greets with Sign in', () => {
-		cy.get('[data-cy="signInTitle"]')
+	it('should greets with Sign in', () => {
+		cy.getBySel('signInTitle')
 			.should('be.visible')
 			.should('contain', 'Sign in to SvelteHipster')
 	})
 
-	it('link to register', () => {
-		cy.get('[data-cy="registerLink"]')
+	it('should display link to register', () => {
+		cy.getBySel('registerLink')
 			.should('have.text', 'Create an account')
 			.should('have.attr', 'href', '/account/register')
 	})
 
-	it('link to forgot password', () => {
-		cy.get('[data-cy="forgotPwdLink"]')
+	it('should display link to forgot password', () => {
+		cy.getBySel('forgotPwdLink')
 			.should('have.text', 'Forgot password?')
 			.should('have.attr', 'href', '/account/reset/init')
 	})
 
-	it('require username and password', () => {
-		cy.get('[data-cy="loginForm"]')
-			.contains('Sign in')
-			.should('be.disabled')
+	it('should require username and password', () => {
+		cy.getBySel('loginForm').contains('Sign in').should('be.disabled')
 	})
 
-	it('require valid username and password', () => {
-		cy.get('[data-cy="loginForm"]')
-			.get('[name="username"]')
+	it('should require username', () => {
+		cy.getBySel('loginForm')
+			.getByName('username')
 			.type('admin')
-			.get('[name="password"]')
+			.clear()
+			.blur()
+		cy.getBySel('loginForm')
+			.getBySel('username-error')
+			.should('be.visible')
+			.and('contain', 'Username is mandatory')
+	})
+
+	it('should require password', () => {
+		cy.getBySel('loginForm')
+			.getByName('password')
+			.type('admin')
+			.clear()
+			.blur()
+		cy.getBySel('loginForm')
+			.getBySel('password-error')
+			.should('be.visible')
+			.and('contain', 'Password is mandatory')
+	})
+
+	it('should require a valid username and password', () => {
+		cy.getBySel('loginForm')
+			.getByName('username')
+			.type('admin')
+			.getByName('password')
 			.type('invalid{enter}')
-		cy.get('[data-cy="errorMsg"]').should(
+		cy.getBySel('errorMsg').should(
 			'contain',
 			'Incorrect username or password.'
 		)
 	})
 
-	it('navigate to / on successful login', () => {
-		cy.get('[data-cy="loginForm"]')
-			.get('[name="username"]')
+	it('should navigate to / on successful login', () => {
+		cy.getBySel('loginForm')
+			.getByName('username')
 			.type('admin')
-			.get('[name="password"]')
+			.getByName('password')
 			.type('admin{enter}')
 		cy.location('pathname').should('eq', '/')
 	})

--- a/generators/client/templates/svelte/cypress/support/commands.js.ejs
+++ b/generators/client/templates/svelte/cypress/support/commands.js.ejs
@@ -1,25 +1,43 @@
 // ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
 // For more comprehensive examples of custom
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
 //
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This is will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('getBySel', (selector, ...args) => {
+	return cy.get(`[data-test=${selector}]`, ...args)
+})
+
+Cypress.Commands.add('getByName', selector => {
+	return cy.get(`[name=${selector}]`)
+})
+
+Cypress.Commands.add('loginByApi', (username, password) => {
+	cy.request({ method: 'GET', url: `api/account`, failOnStatusCode: false })
+		.then(res => {
+			expect(res.status).to.eq(401)
+			return cy.getCookie('XSRF-TOKEN').should('have.property', 'value')
+		})
+		.then(csrfCookie => {
+			return cy.request({
+				method: 'POST',
+				url: `api/authentication`,
+				form: true,
+				headers: {
+					'X-XSRF-TOKEN': csrfCookie,
+				},
+				body: {
+					username: username,
+					password: password,
+					'remember-me': false,
+				},
+			})
+		})
+		.then(res => {
+			expect(res.status).to.eq(200)
+			return cy.request('GET', `api/account`)
+		})
+		.then(res => {
+			expect(res.status).to.eq(200)
+		})
+})

--- a/generators/client/templates/svelte/cypress/support/index.js.ejs
+++ b/generators/client/templates/svelte/cypress/support/index.js.ejs
@@ -1,13 +1,7 @@
 // ***********************************************************
-// This example support/index.js is processed and
-// loaded automatically before your test files.
-//
-// This is a great place to put global configuration and
-// behavior that modifies Cypress.
-//
-// You can change the location of this file or turn off
-// automatically serving support files with the
-// 'supportFile' configuration option.
+// support/index.js is processed and loaded automatically before
+// your test files. This is a great place to put global configuration
+// and behavior that modifies Cypress.
 //
 // You can read more here:
 // https://on.cypress.io/configuration
@@ -15,6 +9,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/generators/client/templates/svelte/package.json.ejs
+++ b/generators/client/templates/svelte/package.json.ejs
@@ -43,6 +43,7 @@
 		"cssnano": "4.1.10",
 		"cypress": "5.3.0",
 		"eslint": "7.10.0",
+		"eslint-plugin-cypress": "2.11.2",
 		"eslint-plugin-svelte3": "2.7.3",
 		"fa-svelte": "3.1.0",
 		<%if (false) {%>
@@ -51,8 +52,8 @@
 		"http-proxy-middleware": "1.0.5",
 		"husky": "4.3.0",
 		"npm-run-all": "4.1.5",
-		"postcss-cli": "8.0.0",
 		"postcss": "8.1.1",
+		"postcss-cli": "8.0.0",
 		"prettier": "2.1.2",
 		"prettier-plugin-svelte": "1.4.0",
 		"pretty-quick": "3.0.2",

--- a/generators/client/templates/svelte/src/main/webapp/app/components/Alert.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/Alert.svelte.ejs
@@ -18,7 +18,7 @@
 	class:text-orange-900="{type === 'warning'}"
 	class="px-7 py-3 mt-4 flex justify-between rounded text-sm"
 >
-	<div>
+	<div {...$$restProps}>
 		<slot />
 	</div>
 	{#if closeable}

--- a/generators/client/templates/svelte/src/main/webapp/app/components/InputControl.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/components/InputControl.svelte.ejs
@@ -77,7 +77,7 @@
 <div class="flex flex-col mt-1 px-3 text-xs text-red-600">
 	<slot message="{message}" dirty="{dirty}" valid="{valid}">
 		{#if dirty && !valid}
-			<div class="flex items-center">
+			<div data-test="{name}-error" class="flex items-center">
 				<Icon class="fa-icon mr-2" icon="{faExclamationCircle}" />
 				{message}
 			</div>

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/account/settings.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/account/settings.svelte.ejs
@@ -44,16 +44,25 @@
 
 <section class="m-3 relative bg-white shadow-md rounded p-4">
 	<div class="p-4 w-full sm:max-w-3xl sm:mx-auto">
-		<div class="px-4 w-full text-4xl text-center">
+		<div data-test="settingsTitle" class="px-4 w-full text-4xl text-center">
 			User settings for [{login}]
 		</div>
-		<Alert show="{settingsUpdated}" closeable="{false}">
+		<Alert
+			data-test="successMsg"
+			show="{settingsUpdated}"
+			closeable="{false}"
+		>
 			Settings changed!
 		</Alert>
-		<Alert type="danger" show="{error}" closeable="{false}">
+		<Alert
+			data-test="errorMsg"
+			type="danger"
+			show="{error}"
+			closeable="{false}"
+		>
 			An error has occurred! The user settings could not be saved.
 		</Alert>
-		<form class="mt-4 flex flex-col">
+		<form data-test="settingsForm" class="mt-4 flex flex-col">
 			<InputControl
 				label="First Name"
 				name="firstName"

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/login.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/login.svelte.ejs
@@ -39,13 +39,19 @@
 				<AppLogo />
 			</div>
 		</div>
-		<div class="mt-4 px-4 w-full text-3xl text-center">
+		<div
+			data-cy="signInTitle"
+			class="mt-4 px-4 w-full text-3xl text-center"
+		>
 			Sign in to SvelteHipster
 		</div>
-		<Alert type="danger" show="{!!authError}">
+		<Alert data-cy="errorMsg" type="danger" show="{!!authError}">
 			Incorrect username or password.
 		</Alert>
-		<form class="mt-4 p-4 flex flex-col bg-white shadow-md rounded">
+		<form
+			data-cy="loginForm"
+			class="mt-4 p-4 flex flex-col bg-white shadow-md rounded"
+		>
 			<InputControl
 				label="Username"
 				name="username"
@@ -92,11 +98,18 @@
 
 		<div class="mt-5 px-4 flex justify-between text-blue-600">
 			<div>
-				<a href="/account/reset/init" class="font-semibold">Forgot password?</a>
+				<a
+					data-cy="forgotPwdLink"
+					href="/account/reset/init"
+					class="font-semibold"
+				>Forgot password?</a>
 			</div>
 			<div>
-				<a href="/account/register" class="font-semibold">Create an
-					account</a>
+				<a
+					data-cy="registerLink"
+					href="/account/register"
+					class="font-semibold"
+				>Create an account</a>
 			</div>
 		</div>
 	</div>

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/login.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/login.svelte.ejs
@@ -40,16 +40,16 @@
 			</div>
 		</div>
 		<div
-			data-cy="signInTitle"
+			data-test="signInTitle"
 			class="mt-4 px-4 w-full text-3xl text-center"
 		>
 			Sign in to SvelteHipster
 		</div>
-		<Alert data-cy="errorMsg" type="danger" show="{!!authError}">
+		<Alert data-test="errorMsg" type="danger" show="{!!authError}">
 			Incorrect username or password.
 		</Alert>
 		<form
-			data-cy="loginForm"
+			data-test="loginForm"
 			class="mt-4 p-4 flex flex-col bg-white shadow-md rounded"
 		>
 			<InputControl
@@ -99,14 +99,14 @@
 		<div class="mt-5 px-4 flex justify-between text-blue-600">
 			<div>
 				<a
-					data-cy="forgotPwdLink"
+					data-test="forgotPwdLink"
 					href="/account/reset/init"
 					class="font-semibold"
 				>Forgot password?</a>
 			</div>
 			<div>
 				<a
-					data-cy="registerLink"
+					data-test="registerLink"
 					href="/account/register"
 					class="font-semibold"
 				>Create an account</a>


### PR DESCRIPTION
Related #7 
---
- Include Cypress `eslint` plugin
- Tests to assert `login` page functionality
- Tests to assert `settings` page functionality
- Common commands like `loginByApi`, `getByName`, `getBySel`