### PR TITLE
Downgrade Jest dependency and use esbuild-jest

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -15,7 +15,6 @@ const svelteFiles = {
 	base: [
 		{
 			templates: [
-				'.babelrc.json',
 				'.eslintignore',
 				'.eslintrc.json',
 				'cypress.json',

--- a/generators/client/templates/svelte/.babelrc.json.ejs
+++ b/generators/client/templates/svelte/.babelrc.json.ejs
@@ -1,3 +1,0 @@
-{
-	"presets": [["@babel/preset-env", { "targets": { "node": "current" } }]]
-}

--- a/generators/client/templates/svelte/jest.config.cjs.ejs
+++ b/generators/client/templates/svelte/jest.config.cjs.ejs
@@ -1,7 +1,7 @@
 module.exports = {
 	testEnvironment: 'jsdom',
 	transform: {
-		'^.+\\.js$': 'babel-jest',
+		'^.+\\.js$': 'esbuild-jest',
 		'^.+\\.svelte$': 'svelte-jester',
 	},
 	testMatch: ['<rootDir>/(<%= CLIENT_MAIN_SRC_DIR %>**/*.spec.js)'],

--- a/generators/client/templates/svelte/package.json
+++ b/generators/client/templates/svelte/package.json
@@ -1,6 +1,5 @@
 {
 	"devDependencies": {
-		"@babel/preset-env": "7.14.5",
 		"@fortawesome/free-solid-svg-icons": "5.15.3",
 		"@fullhuman/postcss-purgecss": "4.0.3",
 		"@sveltejs/adapter-static": "1.0.0-next.13",
@@ -8,9 +7,10 @@
 		"@testing-library/jest-dom": "5.14.1",
 		"@testing-library/svelte": "3.0.3",
 		"autoprefixer": "10.2.6",
-		"babel-jest": "27.0.2",
 		"cssnano": "5.0.6",
 		"cypress": "7.5.0",
+		"esbuild-jest":"0.5.0",
+		"esbuild": "0.12.9",
 		"eslint": "7.28.0",
 		"eslint-plugin-cypress": "2.11.3",
 		"eslint-plugin-jest-dom": "3.9.0",
@@ -18,7 +18,7 @@
 		"eslint-plugin-testing-library": "4.6.0",
 		"fa-svelte": "3.1.0",
 		"husky": "4.3.8",
-		"jest": "27.0.4",
+		"jest": "26.6.3",
 		"jest-junit": "12.2.0",
 		"jest-sonar": "0.2.12",
 		"jest-svelte-resolver": "1.0.0",


### PR DESCRIPTION
`svelte-jester` is not yet compliant with jest v`27` and npm v7 causes peer dependency issues.