### PR TITLE
feat: Generate list, view, delete entity pages

### DIFF
--- a/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
@@ -8,4 +8,16 @@ application {
         cacheProvider caffeine,
         buildTool maven
     }
+    entities *
 }
+
+entity Blog {
+  name String required minlength(5)
+  handle String required minlength(2)
+}
+
+entity Tag {
+  name String required minlength(3)
+}
+
+paginate Tag with pagination

--- a/.github/workflows/scripts/monolithic-jwt-maven-skip-user.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-skip-user.jdl
@@ -9,4 +9,16 @@ application {
         buildTool maven,
         skipUserManagement true
     }
+    entities *
 }
+
+entity Blog {
+  name String required minlength(5)
+  handle String required minlength(2)
+}
+
+entity Tag {
+  name String required minlength(3)
+}
+
+paginate Tag with pagination

--- a/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
+++ b/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
@@ -8,4 +8,16 @@ application {
         cacheProvider caffeine,
         buildTool maven
     }
+    entities *
 }
+
+entity Blog {
+  name String required minlength(5)
+  handle String required minlength(2)
+}
+
+entity Tag {
+  name String required minlength(3)
+}
+
+paginate Tag with pagination

--- a/.github/workflows/scripts/monolithic-session-maven.jdl
+++ b/.github/workflows/scripts/monolithic-session-maven.jdl
@@ -8,4 +8,16 @@ application {
         cacheProvider caffeine,
         buildTool maven
     }
+    entities *
 }
+
+entity Blog {
+  name String required minlength(5)
+  handle String required minlength(2)
+}
+
+entity Tag {
+  name String required minlength(3)
+}
+
+paginate Tag with pagination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@
 
 ### BREAKING CHANGES
 
--   Support `SvelteKit`
+-   ✅ Generate applications using the [`SvelteKit`](https://kit.svelte.dev/) framework in place of `Sapper`
 
 ### Added
 
 -   ✅ Sapper to `SvelteKit` migration. Use `jsconfig` to specify absolute paths from the `lib` directory. `Vite` is now used as the build tool to provide an awful frontend development experience with ESM module builds, Lighting fast HMR, Optimized production bundles [#482](https://github.com/jhipster/generator-jhipster-svelte/pull/482)
--   ✅ Support `OIDC` authentication (`Keycloak` out of the box) [#495](https://github.com/jhipster/generator-jhipster-svelte/pull/495)
+-   ✅ Support `OIDC` authentication (`Keycloak`, `Okta` integration out of the box) [#495](https://github.com/jhipster/generator-jhipster-svelte/pull/495)
+-   ✅ JHipster entity `JDL` support to generate `List`, `View`, and `Delete` entity pages along with `Cypress` e2e tests [#518](https://github.com/jhipster/generator-jhipster-svelte/pull/518)
 
 ### Changed
 
+-   ✅ Bump `JHipster` dependency to support `7.1.0` release [#513] (https://github.com/jhipster/generator-jhipster-svelte/pull/513)
 -   ✅ Bump third party library dependencies.
 
 ## [0.4.0] - 2021-05-30

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Following integrations are supported:
     ✅ Cypress integration for end to end tests
     ✅ Jest and Testing Library integration for unit tests
     ✅ JHipster application JDL
+    ✅ JHipster entity JDL (simple data type, no relation)
 
 Following functional flows are covered with end to end tests:
 
@@ -40,6 +41,8 @@ Following functional flows are covered with end to end tests:
     ✅ Administration
         ✅ User Management (List, Create, Update, View, Delete)
         ✅ Loggers
+    ✅ Entities
+        ✅ Entity (List, View, Delete)
 
 For more details, you can check out the source code of [sample application](https://github.com/jhipster/jhipster-sample-app-svelte)
 
@@ -92,7 +95,19 @@ npm update -g generator-jhipster-svelte
             cacheProvider caffeine,
             buildTool maven
         }
+        entities *
     }
+
+    entity Blog {
+        name String required minlength(3)
+        handle String required minlength(2)
+    }
+
+    entity Tag {
+        name String required minlength(3)
+    }
+
+    paginate Tag with pagination
     ```
 
     Pass `import-jdl` option along the file path to `shipster` cli to generate new application:
@@ -112,8 +127,8 @@ npm update -g generator-jhipster-svelte
 | `JHipster` | `Svelte Hipster` |
 | ---------- | ---------------- |
 | `6.10.5`   | `0.1` - `0.2.1`  |
-| `7.0.0`    | >= `0.3`         |
-|            |                  |
+| `7.0.x`    | `0.3` - `0.4`    |
+| `7.1.x`    | >= `0.5`         |
 
 ## Docker development
 

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -165,6 +165,7 @@ const svelteFiles = {
 				'auth/RoleGuard.svelte',
 				'layout/AccountMenu.svelte',
 				'layout/AdminMenu.svelte',
+				'layout/EntityMenu.svelte',
 				'layout/Footer.svelte',
 				'layout/MenuItem.svelte',
 				'layout/Navbar.svelte',

--- a/generators/client/templates/svelte/cypress/support/commands.js.ejs
+++ b/generators/client/templates/svelte/cypress/support/commands.js.ejs
@@ -82,6 +82,7 @@ Cypress.Commands.add('delete', (url, lenient = true) => {
 				headers: {
 					'X-XSRF-TOKEN': csrfCookie.value,
 				},
+				failOnStatusCode: lenient ? false : true
 			})
 		})
 		.then(res => {

--- a/generators/client/templates/svelte/cypress/support/commands.js.ejs
+++ b/generators/client/templates/svelte/cypress/support/commands.js.ejs
@@ -24,7 +24,7 @@ Cypress.Commands.add('getByName', selector => {
 })
 <%_ if (authenticationType === 'session') { _%>
 Cypress.Commands.add('loginByApi', (username, password) => {
-	cy.request({ method: 'GET', url: `api/authenticate` })
+	cy.request({ url: `api/authenticate` })
 		.then(res => {
 			expect(res.status).to.eq(200)
 			return cy.getCookie('XSRF-TOKEN').should('have.property', 'value')
@@ -52,6 +52,165 @@ Cypress.Commands.add('loginByApi', (username, password) => {
 			expect(res.status).to.eq(200)
 		})
 })
+<%_ } else if (authenticationType === 'jwt') { _%>
+Cypress.Commands.add('loginByApi', (username, password) => {
+	cy.request({
+			method: 'POST',
+			url: `api/authenticate`,
+			body: {
+				username: username,
+				password: password,
+				'remember-me': false,
+			},
+		})
+	.then(res => {
+		expect(res.status).to.eq(200)
+		localStorage.setItem('authToken', res.body.id_token)
+		return cy.request({
+			url: `api/account`,
+			headers: {
+				'Authorization': `Bearer ${res.body.id_token}`
+			}
+		})
+	})
+	.then(res => {
+		expect(res.status).to.eq(200)
+	})
+})
+
+Cypress.Commands.add('save', (url, body, status = 201) => {
+	cy.request({
+		method: 'POST',
+		url: url,
+		form: false,
+		headers: {
+			Authorization: `Bearer ${localStorage.getItem('authToken') || sessionStorage.getItem('authToken')}`,
+			'Content-Type': 'application/json',
+		},
+		body: body,
+	})
+	.then(res => {
+		expect(res.status).to.eq(status)
+		return cy.wrap(res.body)
+	})
+})
+
+Cypress.Commands.add('delete', (url, lenient = true) => {
+	cy.request({
+		method: 'DELETE',
+		url: url,
+		headers: {
+			Authorization: `Bearer ${localStorage.getItem('authToken') || sessionStorage.getItem('authToken')}`,
+		},
+		failOnStatusCode: lenient ? false : true
+	})
+	.then(res => {
+		if (!lenient) {
+			expect(res.status).to.eq(204)
+		}
+	})
+})
+<%_ } else { _%>
+
+Cypress.Commands.add('loginByApi', (username, password) => {
+
+	cy.request({
+		url: '/oauth2/authorization/oidc',
+		followRedirect: false,
+	})
+		.its('headers.location')
+		.as('authorizeUrl')
+		.then(function(){
+			const url = new URL(this.authorizeUrl);
+			const origin = url.origin
+
+			if(origin.includes('okta')) {
+				cy.request({
+					method: 'POST',
+					url: `${origin}/api/v1/authn`,
+					followRedirect: false,
+					body: {
+						username,
+						password,
+					},
+				})
+					.its('body.sessionToken')
+					.as('sessionToken')
+					.then(function() {
+						const sessionToken = this.sessionToken
+						cy.request({
+							url: `${this.authorizeUrl}&sessionToken=${sessionToken}`,
+							followRedirect: true,
+						})
+					})
+			} else {
+				cy.request({
+					url: `/oauth2/authorization/oidc`,
+					followRedirect: true,
+				})
+					.then(res => {
+						const html = document.createElement('html')
+						html.innerHTML = res.body
+						const form = html.getElementsByTagName('form')[0]
+						const url = form.action
+						return cy.request({
+							method: 'POST',
+							url,
+							followRedirect: false,
+							form: true,
+							body: {
+								username: username,
+								password: password,
+							},
+						})
+					})
+					.then(() => {
+						return cy.request({
+							url: '/oauth2/authorization/oidc',
+							followRedirect: true,
+						})
+					})
+			}
+		})
+})
+
+Cypress.Commands.add('logoutByApi', () => {
+	cy.getCookie('XSRF-TOKEN')
+		.then(csrfCookie => {
+			return cy.request({
+				method: 'POST',
+				url: `api/logout`,
+				headers: {
+					'X-XSRF-TOKEN': csrfCookie.value,
+				},
+			})
+		})
+		.then(res => {
+			expect(res.status).to.eq(200)
+			let logoutUrl = res.body.logoutUrl
+			let redirectUri
+			cy.location().then(loc$ => {
+				redirectUri = loc$.origin
+				// Keycloak: uri has protocol/openid-connect/token
+				if (logoutUrl.includes('/protocol')) {
+					logoutUrl = `${logoutUrl}?redirect_uri=${redirectUri}`
+				} else {
+					// Else, Okta
+					logoutUrl = `${logoutUrl}?id_token_hint=${res.body.idToken}&post_logout_redirect_uri=${redirectUri}`
+				}
+				return cy.request({
+					url: logoutUrl,
+					followRedirect: true,
+				})
+			})
+		})
+		.then(res => {
+			expect(res.status).to.eq(200)
+			cy.visit('/')
+		})
+})
+<%_ }
+	if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
 
 Cypress.Commands.add('save', (url, body, status = 201) => {
 	cy.getCookie('XSRF-TOKEN')
@@ -89,167 +248,6 @@ Cypress.Commands.add('delete', (url, lenient = true) => {
 			if (!lenient) {
 				expect(res.status).to.eq(204)
 			}
-		})
-})
-<%_ } else if (authenticationType === 'jwt') { _%>
-Cypress.Commands.add('loginByApi', (username, password) => {
-	cy.request({
-			method: 'POST',
-			url: `api/authenticate`,
-			body: {
-				username: username,
-				password: password,
-				'remember-me': false,
-			},
-		})
-	.then(res => {
-		expect(res.status).to.eq(200)
-		localStorage.setItem('authToken', res.body.id_token)
-		return cy.request({
-			method: 'GET',
-			url: `api/account`,
-			headers: {
-				'Authorization': `Bearer ${res.body.id_token}`
-			}
-		})
-	})
-	.then(res => {
-		expect(res.status).to.eq(200)
-	})
-})
-
-Cypress.Commands.add('save', (url, body, status = 201) => {
-	cy.request({
-		method: 'POST',
-		url: url,
-		form: false,
-		headers: {
-			Authorization: `Bearer ${localStorage.getItem('authToken') || sessionStorage.getItem('authToken')}`,
-			'Content-Type': 'application/json',
-		},
-		body: body,
-	})
-	.then(res => {
-		expect(res.status).to.eq(status)
-		return cy.wrap(res.body)
-	})
-})
-
-Cypress.Commands.add('delete', (url, lenient = true) => {
-	cy.request({
-		method: 'DELETE',
-		url: url,
-		headers: {
-			Authorization: `Bearer ${localStorage.getItem('authToken') || sessionStorage.getItem('authToken')}`,
-		},
-	})
-	.then(res => {
-		if (!lenient) {
-			expect(res.status).to.eq(204)
-		}
-	})
-})
-<%_ } else { _%>
-
-Cypress.Commands.add('loginByApi', (username, password) => {
-
-	cy.request({
-		url: '/oauth2/authorization/oidc',
-		followRedirect: false,
-	})
-		.its('headers.location')
-		.as('authorizeUrl')
-		.then(function(){
-			const url = new URL(this.authorizeUrl);
-			const origin = url.origin
-
-			if(origin.includes('okta')) {
-				cy.request({
-					method: 'POST',
-					url: `${origin}/api/v1/authn`,
-					followRedirect: false,
-					body: {
-						username,
-						password,
-					},
-				})
-					.its('body.sessionToken')
-					.as('sessionToken')
-					.then(function() {
-						const sessionToken = this.sessionToken
-						cy.request({
-							method: 'GET',
-							url: `${this.authorizeUrl}&sessionToken=${sessionToken}`,
-							followRedirect: true,
-						})
-					})
-			} else {
-				cy.request({
-					method: 'GET',
-					url: `/oauth2/authorization/oidc`,
-					followRedirect: true,
-				})
-					.then(res => {
-						const html = document.createElement('html')
-						html.innerHTML = res.body
-						const form = html.getElementsByTagName('form')[0]
-						const url = form.action
-						return cy.request({
-							method: 'POST',
-							url,
-							followRedirect: false,
-							form: true,
-							body: {
-								username: username,
-								password: password,
-							},
-						})
-					})
-					.then(() => {
-						return cy.request({
-							method: 'GET',
-							url: '/oauth2/authorization/oidc',
-							followRedirect: true,
-						})
-					})
-			}
-		})
-})
-
-Cypress.Commands.add('logoutByApi', () => {
-	cy.getCookie('XSRF-TOKEN')
-		.then(csrfCookie => {
-			return cy.request({
-				method: 'POST',
-				url: `api/logout`,
-				headers: {
-					'X-XSRF-TOKEN': csrfCookie.value,
-				},
-			})
-		})
-		.then(res => {
-			expect(res.status).to.eq(200)
-			let logoutUrl = res.body.logoutUrl
-			let redirectUri
-			cy.location().then(loc$ => {
-				redirectUri = loc$.origin
-				// Keycloak: uri has protocol/openid-connect/token
-				if (logoutUrl.includes('/protocol')) {
-					logoutUrl = `${logoutUrl}?redirect_uri=${redirectUri}`
-				} else {
-					// Else, Okta
-					logoutUrl = `${logoutUrl}?id_token_hint=${res.body.idToken}&post_logout_redirect_uri=${redirectUri}`
-				}
-				return cy.request({
-					method: 'GET',
-					url: logoutUrl,
-					followRedirect: true,
-				})
-			})
-		})
-		.then(res => {
-			expect(res.status).to.eq(200)
-			cy.visit('/')
 		})
 })
 <%_ } _%>

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/layout/EntityMenu.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/layout/EntityMenu.svelte.ejs
@@ -1,0 +1,44 @@
+<script>
+	import { faAsterisk } from '@fortawesome/free-solid-svg-icons/faAsterisk.js'
+	import { faList } from '@fortawesome/free-solid-svg-icons/faList.js'
+	import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown.js'
+
+	import MenuItem from '$lib/layout/MenuItem.svelte'
+	import Icon from '$lib/Icon.svelte'
+
+	let isOpen = false
+</script>
+
+<div class="px-2 pt-2 pb-2 sm:p-0 relative sm:flex sm:mr-2">
+	<div
+		class="px-2 py-1 sm:py-0 flex justify-start items-center rounded sm:rounded-none font-semibold hover:text-white hover:bg-gray-700 sm:hover:bg-transparent focus:outline-none focus:ring focus:ring-primary-500"
+	>
+		<button
+			aria-label="Entities Menu"
+			data-test="svlEntityLink"
+			on:click="{() => (isOpen = !isOpen)}"
+			class="sm:h-8 sm:px-2 sm:w-auto sm:flex sm:justify-center focus:font-semibold sm:items-center sm:rounded border-0 text-gray-400 focus:text-white focus:outline-none focus:ring focus:ring-primary-500"
+		>
+			<span class="leading-none">
+				<Icon classes="sm:mr-1" icon="{faList}" />
+			</span>
+			<span>Entities</span>
+			<span>
+				<Icon classes="ml-1" icon="{faCaretDown}" />
+			</span>
+		</button>
+	</div>
+	{#if isOpen}
+		<button
+			tabindex="-1"
+			on:click="{() => (isOpen = false)}"
+			class="fixed hidden sm:block inset-0 w-full h-full bg-gray-400
+				opacity-50 cursor-default"></button>
+	{/if}
+	<div
+		class:hidden="{!isOpen}"
+		class="sm:absolute sm:right-0 sm:mt-10 sm:w-48 py-2 sm:bg-white sm:dark:bg-gray-700 rounded sm:rounded-lg sm:shadow-lg"
+	>
+		<!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
+	</div>
+</div>

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/layout/Navbar.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/layout/Navbar.svelte.ejs
@@ -10,6 +10,7 @@
 	import auth from '$lib/auth/auth-store.js'
 	import AccountMenu from '$lib/layout/AccountMenu.svelte'
 	import AdminMenu from '$lib/layout/AdminMenu.svelte'
+	import EntityMenu from '$lib/layout/EntityMenu.svelte'
 	import RoleGuard from '$lib/auth/RoleGuard.svelte'
 	import ThemeModeToggle from '$lib/layout/ThemeModeToggle.svelte'
 
@@ -65,6 +66,9 @@
 			<ThemeModeToggle />
 		</div>
 		{#if $auth}
+			<div data-test="svlEntityMenu" class="sm:ml-4">
+				<EntityMenu />
+			</div>
 			<RoleGuard role="ADMIN">
 				<div data-test="svlAdminMenu" class="sm:ml-4">
 					<AdminMenu />

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/login.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/login.svelte.ejs
@@ -51,7 +51,12 @@
 	<div class="p-4 w-full sm:w-[450px] mx-4 sm:m-0">
 		<div class="px-4 py-3 mt-4 sm:mx-0 flex justify-center">
 			<div class="w-3/4 dark:text-primary-100">
-				<img src="{appLogo}" width="420" height="90" alt="Application Logo" />
+				<img
+					src="{appLogo}"
+					width="420"
+					height="90"
+					alt="Application Logo"
+				/>
 			</div>
 		</div>
 		<div

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -1,0 +1,63 @@
+const mkdirp = require('mkdirp');
+const constants = require('generator-jhipster/generators/generator-constants');
+const util = require('../util');
+
+const FRONTEND_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+const FRONTEND_APP_DIR = constants.ANGULAR_DIR;
+const FRONTEND_ROUTES_DIR = `${FRONTEND_APP_DIR}/routes/entities/`;
+const FRONTEND_COMPONENTS_DIR = `${FRONTEND_APP_DIR}/lib/entities/`;
+const CLIENT_TEMPLATES_DIR = 'svelte';
+
+module.exports = {
+	writeFiles,
+};
+
+const svelteFiles = {
+	entityRoutes: [
+		{
+			path: FRONTEND_ROUTES_DIR,
+			templates: [
+				{
+					file: 'entity/index.svelte',
+					renameTo: generator => `${generator.entityFolderName}/index.svelte`,
+				},
+				{
+					file: 'entity/[id]/view.svelte',
+					renameTo: generator => `${generator.entityFolderName}/[id]/view.svelte`,
+				},
+			],
+		},
+	],
+	entityLib: [
+		{
+			path: FRONTEND_COMPONENTS_DIR,
+			templates: [
+				{
+					file: 'entity/EntityDeleteModal.svelte',
+					renameTo: generator =>
+						`${generator.entityFolderName}/${generator.entityAngularName}DeleteModal.svelte`,
+				},
+				{
+					file: 'entity/EntityListActions.svelte',
+					renameTo: generator =>
+						`${generator.entityFolderName}/${generator.entityAngularName}ListActions.svelte`,
+				},
+				{
+					file: 'entity/EntityTable.svelte',
+					renameTo: generator => `${generator.entityFolderName}/${generator.entityAngularName}Table.svelte`,
+				},
+				{
+					file: 'entity/entity-service.js',
+					renameTo: generator => `${generator.entityFolderName}/${generator.entityInstance}-service.js`,
+				},
+			],
+		},
+	],
+};
+
+function writeFiles() {
+	mkdirp(FRONTEND_SRC_DIR);
+	this.writeFilesToDisk(svelteFiles, this, false, `${CLIENT_TEMPLATES_DIR}`);
+
+	util.addEntityToMenu(this, this.entityFolderName, this.entityAngularName, this.entityAngularName);
+}

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -53,6 +53,27 @@ const svelteFiles = {
 			],
 		},
 	],
+	entityE2eTests: [
+		{
+			templates: [
+				{
+					file: 'cypress/integration/entities/entity/entity-delete.spec.js',
+					renameTo: generator =>
+						`cypress/integration/entities/${generator.entityFolderName}/${generator.entityInstance}-delete.spec.js`,
+				},
+				{
+					file: 'cypress/integration/entities/entity/entity-list.spec.js',
+					renameTo: generator =>
+						`cypress/integration/entities/${generator.entityFolderName}/${generator.entityInstance}-list.spec.js`,
+				},
+				{
+					file: 'cypress/integration/entities/entity/entity-view.spec.js',
+					renameTo: generator =>
+						`cypress/integration/entities/${generator.entityFolderName}/${generator.entityInstance}-view.spec.js`,
+				},
+			],
+		},
+	],
 };
 
 function writeFiles() {

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -1,0 +1,66 @@
+const chalk = require('chalk');
+const EntityClientGenerator = require('generator-jhipster/generators/entity-client');
+const writeFiles = require('./files').writeFiles;
+const blueprintPackageJson = require('../../package.json');
+
+module.exports = class extends EntityClientGenerator {
+	constructor(args, opts) {
+		super(args, { ...opts, fromBlueprint: true });
+
+		const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+		if (!jhContext) {
+			this.error(
+				`This is a JHipster blueprint and should be used like ${chalk.yellow('jhipster --blueprints svelte')}`
+			);
+		}
+
+		this.configOptions = jhContext.configOptions || {};
+		this.blueprintjs = blueprintPackageJson;
+	}
+
+	get initializing() {
+		return super._initializing();
+	}
+
+	get prompting() {
+		return super._prompting();
+	}
+
+	get configuring() {
+		return super._configuring();
+	}
+
+	get composing() {
+		return super._composing();
+	}
+
+	get loading() {
+		return super._loading();
+	}
+
+	get preparing() {
+		return super._preparing();
+	}
+
+	get default() {
+		return super._default();
+	}
+
+	get writing() {
+		return {
+			writeAdditionalFile() {
+				writeFiles.call(this);
+			},
+		};
+	}
+
+	get postWriting() {
+		// TODO: add menu option changes
+		return {};
+	}
+
+	get end() {
+		return super._end();
+	}
+};

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -47,6 +47,7 @@ module.exports = class extends EntityClientGenerator {
 		return super._default();
 	}
 
+	// eslint-disable-next-line class-methods-use-this
 	get writing() {
 		return {
 			writeAdditionalFile() {
@@ -55,6 +56,7 @@ module.exports = class extends EntityClientGenerator {
 		};
 	}
 
+	// eslint-disable-next-line class-methods-use-this
 	get postWriting() {
 		// TODO: add menu option changes
 		return {};

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -1,0 +1,78 @@
+describe('<%= entityAngularName %> delete dialog page', () => {
+	let randomPrefix
+	let dynamicId
+
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		randomPrefix = 'test' + new Date().getTime()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+
+		cy.save('api/<%= entityApiUrl %>', {
+		<%_
+			for (field of fields.filter(field => !field.id)) {
+		_%>
+			<%= field.fieldName %>: randomPrefix,
+		<%_ } _%>
+		}).then(res => {
+			dynamicId = res.id
+		})
+
+		cy.visit('/entities/<%= entityFolderName %>')
+
+		cy.getBySel('<%= entityInstance %>Table')
+			.contains('td', randomPrefix)
+			.parent()
+			.trigger('mouseenter')
+			.within($tr => {
+				cy.root()
+					.get('td')
+					.children()
+					.getByName('delete<%= entityAngularName %>Btn')
+					.click()
+			})
+	})
+
+	afterEach(() => {
+		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`, true)
+	})
+
+	it('should display delete <%= entityAngularName %> dialog', () => {
+		cy.getBySel('svlModal').within(() => {
+			cy.root()
+				.get('h1')
+				.should('be.visible')
+				.should('contain', 'Confirm delete operation')
+				.get('p')
+				.should('be.visible')
+				.should('contain', 'Are you sure you want to delete the <%= entityAngularName %>?')
+				.getByName('delete<%= entityAngularName %>Btn')
+				.should('not.be.disabled')
+				.getByName('cancelBtn')
+				.should('not.be.disabled')
+		})
+	})
+
+	it('should close the dialog without deleting <%= entityAngularName %>', () => {
+		cy.getBySel('svlModal').within(() => cy.getByName('cancelBtn').click())
+		cy.getBySel('<%= entityInstance %>Title')
+			.should('be.visible')
+			.should('contain', '<%= entityClassPluralHumanized %>')
+	})
+
+	it('should delete the <%= entityAngularName %>', () => {
+		cy.getBySel('svlModal').within(() =>
+			cy.getByName('delete<%= entityAngularName %>Btn').click()
+		)
+
+		cy.getBySel('toast-success').contains(
+			'A <%= entityInstance %> is deleted with identifier'
+		)
+
+		cy.getBySel('<%= entityInstance %>Title')
+			.should('be.visible')
+			.should('contain', '<%= entityClassPluralHumanized %>')
+	})
+})

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -37,6 +37,9 @@ describe('<%= entityAngularName %> delete dialog page', () => {
 
 	afterEach(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`, true)
+	<%_ if (authenticationType === 'oauth2') { _%>
+		cy.logoutByApi()
+	<%_ } _%>
 	})
 
 	it('should display delete <%= entityAngularName %> dialog', () => {

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -41,6 +41,9 @@ describe('<%= entityAngularName %> list page', () => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
 	<%_ if (!paginationNo) { _%>
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId2}`)
+	<%_ }
+	if (authenticationType === 'oauth2') { _%>
+		cy.logoutByApi()
 	<%_ } _%>
 	})
 

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -1,0 +1,131 @@
+describe('<%= entityAngularName %> list page', () => {
+	let randomPrefix
+	let dynamicId
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		randomPrefix = 'test' + new Date().getTime()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+		cy.save('api/<%= entityApiUrl %>', {
+		<%_
+			for (field of fields.filter(field => !field.id)) {
+		_%>
+			<%= field.fieldName %>: randomPrefix,
+		<%_ } _%>
+		}).then(res => {
+			dynamicId = res.id
+			cy.visit('/entities/<%= entityFolderName %>')
+		})
+
+	})
+
+	afterEach(() => {
+		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
+	})
+
+	it('should greets with <%= entityAngularName %> page title', () => {
+		cy.getBySel('<%= entityInstance %>Title')
+			.should('be.visible')
+			.should('contain', '<%= entityClassPluralHumanized %>')
+	})
+
+	it('should display <%= entityAngularName %> table', () => {
+		cy.getBySel('<%= entityInstance %>Table')
+			.should('be.visible')
+			.get('tr')
+			.eq(0)
+			.children()
+<%_
+	for (let loopIndex = 0; loopIndex > fields.length; loopIndex++) {
+		const field = fields[loopIndex];
+_%>
+			.should('have.length', <%= fields.length %>)
+			.get('th')
+			.eq(<%= loopIndex %>)
+			.should('contain', '<%= field.fieldNameHumanized %>')
+<%_ } _%>
+	})
+
+	it('should display <%= entityAngularName %> record in the table', () => {
+		cy.getBySel('<%= entityInstance %>Table')
+			.get('tbody tr')
+			.eq(0)
+			.within($tr => {
+				cy.root()
+<%_
+	for (let loopIndex = 0; loopIndex > fields.length; loopIndex++) {
+_%>
+					.get('td')
+					.eq(<%= loopIndex %>)
+					.should('not.be.empty')
+<%_ } _%>
+			})
+	})
+
+<%_ if (!paginationNo) { _%>
+	it('should validate the pagination controls', () => {
+		cy.getBySel('pageCtrl')
+			.eq(0)
+			.contains('div', /1-\d+ of \d+/)
+			.next()
+			.within($div => {
+				cy.root()
+					.getBySel('prevPageCtrl')
+					.should('be.disabled')
+					.get('div')
+					.should('have.text', '1')
+					.getBySel('nextPageCtrl')
+					.should('be.disabled')
+			})
+	})
+
+	it('should sort the records by Id field', () => {
+		let valueBeforeSort
+
+		cy.getBySel('<%= entityInstance %>Table')
+			.get('tbody>tr')
+			.eq(0)
+			.within($tr => {
+				cy.root()
+					.get('td')
+					.eq(0)
+					.invoke('text')
+					.then(text => (valueBeforeSort = text))
+			})
+
+		cy.intercept('**/api/tags?*').as('get<%= entityClassPluralHumanized %>')
+
+		cy.getBySel('<%= entityInstance %>Table')
+			.get('tr')
+			.eq(0)
+			.within($tr => {
+				cy.root()
+					.get('th')
+					.eq(0)
+					.within($td => {
+						cy.root().get('span').eq(1).click()
+					})
+			})
+
+		cy.wait('@get<%= entityClassPluralHumanized %>')
+
+		// eslint-disable-next-line
+		cy.wait(100)
+
+		cy.getBySel('<%= entityInstance %>Table')
+			.get('tbody>tr')
+			.eq(0)
+			.within($tr => {
+				cy.root()
+					.get('td')
+					.eq(0)
+					.invoke('text')
+					.then(text => {
+						expect(text).not.eq(valueBeforeSort)
+					})
+			})
+	})
+<%_ } _%>
+})

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -1,13 +1,30 @@
 describe('<%= entityAngularName %> list page', () => {
 	let randomPrefix
 	let dynamicId
+<%_ if (!paginationNo) { _%>
+	let randomPrefix2
+	let dynamicId2
+<%_ } _%>
 	beforeEach(() => {
 		cy.unregisterServiceWorkers()
-		randomPrefix = 'test' + new Date().getTime()
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
 			Cypress.env('adminPassword')
 		)
+	<%_ if (!paginationNo) { _%>
+		// create another <%= entityAngularName %> to test sort implementation
+		randomPrefix = 'zest' + new Date().getTime()
+		cy.save('api/<%= entityApiUrl %>', {
+		<%_
+			for (field of fields.filter(field => !field.id)) {
+		_%>
+			<%= field.fieldName %>: randomPrefix2,
+		<%_ } _%>
+		}).then(res => {
+			dynamicId2 = res.id
+		})
+	<%_ } _%>
+		randomPrefix = 'test' + new Date().getTime()
 		cy.save('api/<%= entityApiUrl %>', {
 		<%_
 			for (field of fields.filter(field => !field.id)) {
@@ -18,11 +35,13 @@ describe('<%= entityAngularName %> list page', () => {
 			dynamicId = res.id
 			cy.visit('/entities/<%= entityFolderName %>')
 		})
-
 	})
 
 	afterEach(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
+	<%_ if (!paginationNo) { _%>
+		cy.delete(`api/<%= entityApiUrl %>/${dynamicId2}`)
+	<%_ } _%>
 	})
 
 	it('should greets with <%= entityAngularName %> page title', () => {

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -13,7 +13,7 @@ describe('<%= entityAngularName %> list page', () => {
 		)
 	<%_ if (!paginationNo) { _%>
 		// create another <%= entityAngularName %> to test sort implementation
-		randomPrefix = 'zest' + new Date().getTime()
+		randomPrefix2 = 'zest' + new Date().getTime()
 		cy.save('api/<%= entityApiUrl %>', {
 		<%_
 			for (field of fields.filter(field => !field.id)) {

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -24,6 +24,9 @@ describe('<%= entityAngularName %> view details page', () => {
 
 	afterEach(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
+	<%_ if (authenticationType === 'oauth2') { _%>
+		cy.logoutByApi()
+	<%_ } _%>
 	})
 
 	it('should display <%= entityAngularName %> details', () => {

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -1,0 +1,54 @@
+describe('<%= entityAngularName %> view details page', () => {
+	let randomPrefix
+	let dynamicId
+
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		randomPrefix = 'test' + new Date().getTime()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+
+		cy.save('api/<%= entityApiUrl %>', {
+		<%_
+			for (field of fields.filter(field => !field.id)) {
+		_%>
+			<%= field.fieldName %>: randomPrefix,
+		<%_ } _%>
+		}).then(res => {
+			dynamicId = res.id
+			cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/view`)
+		})
+	})
+
+	afterEach(() => {
+		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
+	})
+
+	it('should display <%= entityAngularName %> details', () => {
+		cy.getBySel('<%= entityInstance %>Title')
+			.should('be.visible')
+			.and('contain', `<%= entityAngularName %> Details`)
+
+		cy.get('div.table').within(() => {
+			cy.root()
+				.get('.table-cell')
+				.should('have.length', <%= (fields.length - 1) * 2 %>)
+			<%_
+				for (let loopIndex = 1; loopIndex > fields.length * 2; loopIndex= loopIndex + 2) {
+			_%>
+				.get('.table-cell')
+				.eq(<%= loopIndex %>)
+				.should('contain', randomPrefix)
+			<%_ }_%>
+		})
+	})
+
+	it('should navigate back to the <%= entityAngularName %> list page', () => {
+		cy.getByName('backBtn').click()
+		cy.getBySel('<%= entityInstance %>Title')
+			.should('be.visible')
+			.should('contain', '<%= entityClassPluralHumanized %>')
+	})
+})

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityDeleteModal.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityDeleteModal.svelte.ejs
@@ -1,0 +1,34 @@
+<script>
+	import { createEventDispatcher } from 'svelte'
+	import { faBan } from '@fortawesome/free-solid-svg-icons/faBan.js'
+	import { faTrashAlt } from '@fortawesome/free-solid-svg-icons/faTrashAlt.js'
+
+	import Button from '$lib/Button.svelte'
+	import Icon from '$lib/Icon.svelte'
+	import Modal from '$lib/Modal.svelte'
+
+	export let id = ''
+	const dispatch = createEventDispatcher()
+</script>
+
+<Modal title="Confirm delete operation" on:close="{() => dispatch('close')}">
+	<p class="w-[450px]">Are you sure you want to delete the <%= entityClassHumanized %>?</p>
+	<div slot="footer">
+		<Button
+			name="cancelBtn"
+			role="neutral"
+			classes="mr-4"
+			on:click="{() => dispatch('close')}"
+		>
+			<Icon classes="mr-2" icon="{faBan}" />Cancel
+		</Button>
+
+		<Button
+			name="delete<%= entityAngularName %>Btn"
+			role="danger"
+			on:click="{() => dispatch('delete<%= entityAngularName %>', { id })}"
+		>
+			<Icon classes="mr-2" icon="{faTrashAlt}" />Delete
+		</Button>
+	</div>
+</Modal>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityListActions.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityListActions.svelte.ejs
@@ -1,0 +1,60 @@
+<script>
+	import { createEventDispatcher } from 'svelte'
+	import { faEye } from '@fortawesome/free-solid-svg-icons/faEye.js'
+	import { faPencilAlt } from '@fortawesome/free-solid-svg-icons/faPencilAlt.js'
+	import { faTrashAlt } from '@fortawesome/free-solid-svg-icons/faTrashAlt.js'
+
+	import Button from '$lib/Button.svelte'
+	import Icon from '$lib/Icon.svelte'
+
+	export let <%= entityInstance %>
+	export let showActions = false
+	const dispatch = createEventDispatcher()
+</script>
+
+<div
+	class="flex flex-row justify-center items-center leading-none"
+	class:hidden="{!showActions}"
+	data-testid="rowactions"
+>
+	<Button
+		name="view<%= entityAngularName %>Btn"
+		role="action"
+		classes="sm:my-0"
+		title="View"
+		aria-label="view"
+		on:click="{() =>
+			dispatch('view<%= entityInstance %>', {
+				id: <%= entityInstance %>.id,
+			})}"
+	>
+		<Icon icon="{faEye}" />
+	</Button>
+	<Button
+		name="edit<%= entityAngularName %>Btn"
+		role="action"
+		classes="sm:my-0"
+		disabled="disabled"
+		title="Edit"
+		aria-label="edit"
+		on:click="{() =>
+			dispatch('update<%= entityInstance %>', {
+				id: <%= entityInstance %>.id,
+			})}"
+	>
+		<Icon icon="{faPencilAlt}" />
+	</Button>
+	<Button
+		name="delete<%= entityAngularName %>Btn"
+		role="action"
+		classes="sm:my-0"
+		title="Delete"
+		aria-label="delete"
+		on:click="{() =>
+			dispatch('delete<%= entityInstance %>', {
+				id: <%= entityInstance %>.id,
+			})}"
+	>
+		<Icon icon="{faTrashAlt}" />
+	</Button>
+</div>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityTable.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityTable.svelte.ejs
@@ -12,7 +12,7 @@
 <%_ } _%>
 </script>
 
-<Table testId="<%= entityInstance %>Table">
+<Table testId="<%= entityInstance %>">
 	<thead slot="head">
 		<TableRow classes="bg-gray-100 dark:bg-gray-700">
 			<TableHeader>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityTable.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityTable.svelte.ejs
@@ -1,0 +1,65 @@
+<script>
+	import <%= entityAngularName %>ListActions from '$lib/entities/<%= entityFolderName %>/<%= entityAngularName %>ListActions.svelte'
+	import Sort from '$lib/table/Sort.svelte'
+	import Table from '$lib/table/Table.svelte'
+	import TableData from '$lib/table/TableData.svelte'
+	import TableHeader from '$lib/table/TableHeader.svelte'
+	import TableRow from '$lib/table/TableRow.svelte'
+
+	export let <%= entityInstancePlural %> = []
+<%_ if (!paginationNo) { _%>
+	export let sortPredicate = 'id'
+<%_ } _%>
+</script>
+
+<Table testId="<%= entityInstance %>Table">
+	<thead slot="head">
+		<TableRow classes="bg-gray-100 dark:bg-gray-700">
+			<TableHeader>
+				<span>ID</span>
+				<%_ if (!paginationNo) { _%>
+				<Sort
+					active="{sortPredicate === 'id'}"
+					sortPredicate="id"
+					on:sortbypredicate
+				/>
+				<%_ } _%>
+			</TableHeader>
+		<%_ for (field of fields.filter(field => !field.id)) { _%>
+			<TableHeader>
+				<span><%= field.fieldNameHumanized %></span>
+			<%_ if (!paginationNo) { _%>
+				<Sort
+					active="{sortPredicate === '<%= field.fieldName%>'}"
+					sortPredicate="<%= field.fieldName%>"
+					on:sortbypredicate
+				/>
+			<%_ } _%>
+			</TableHeader>
+		<%_ } _%>
+			<TableHeader />
+		</TableRow>
+	</thead>
+	<tbody>
+		{#each <%= entityInstancePlural %> as <%= entityInstance %> (<%= entityInstance %>.id)}
+			<TableRow let:showActions>
+				<TableData>{<%= entityInstance %>.id}</TableData>
+			<%_
+				for (field of fields.filter(field => !field.id)) {
+			_%>
+				<TableData>{<%=entityInstance %>.<%= field.fieldName %>}</TableData>
+			<%_ } _%>
+				<TableData classes="w-48 {showActions ? 'sm:py-0' : ''}">
+					<div class:hidden="{showActions}">&nbsp;</div>
+					<<%= entityAngularName %>ListActions
+						<%= entityInstance %>="{<%= entityInstance %>}"
+						showActions="{showActions}"
+						on:view<%= entityInstance %>
+						on:update<%= entityInstance %>
+						on:delete<%= entityInstance %>
+					/>
+				</TableData>
+			</TableRow>
+		{/each}
+	</tbody>
+</Table>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/entity-service.js.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/entity-service.js.ejs
@@ -1,0 +1,30 @@
+import { serverUrl } from '$lib/utils/env'
+import { request } from '$lib/utils/request'
+<%_
+const baseApi = (applicationTypeGateway && locals.microserviceName) ? 'services/' + microserviceName.toLowerCase() + '/api/' : 'api/';
+_%>
+export default {
+<%_ if (!readOnly) { _%>
+	create: entity =>
+		request(`${serverUrl}<%= baseApi + entityApiUrl %>`, 'POST', JSON.stringify(entity), {
+			'Content-Type': 'application/json',
+		}),
+<%_ } _%>
+	findAll: (<% if (!paginationNo) { %>page, size, sortPredicate, sortOrder<% } %>) => {
+	<%_ if (!paginationNo) { _%>
+		const defaultSort = sortPredicate !== 'id' ? '&sort=id,asc' : ''
+		const queryString = `page=${
+			page - 1
+		}&size=${size}&sort=${sortPredicate},${sortOrder}${defaultSort}`
+	<%_ } _%>
+		return request(`${serverUrl}<%= baseApi + entityApiUrl %><% if (!paginationNo) { %>?${queryString}<% } %>`)
+	},
+	findById: id => request(`${serverUrl}<%= baseApi + entityApiUrl %>/${id}`),
+<%_ if (!readOnly) { _%>
+	update: entity =>
+		request(`${serverUrl}<%= baseApi + entityApiUrl %>`, 'PUT', JSON.stringify(entity), {
+			'Content-Type': 'application/json',
+		}),
+	delete: id => request(`${serverUrl}<%= baseApi + entityApiUrl %>/${id}`, 'DELETE'),
+<%_ } _%>
+}

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/[id]/view.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/[id]/view.svelte.ejs
@@ -29,7 +29,7 @@
 	<title><%= entityClassHumanized %> Details</title>
 	<meta name="Description" content="<%= entityClassHumanized %> details" />
 </svelte:head>
-<Page testId="<%= entityInstance %>Mgmt" width="full">
+<Page testId="<%= entityInstance %>" width="full">
 	<div class="text-left" slot="header">
 		<%= entityClassHumanized %> Details
 	</div>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/[id]/view.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/[id]/view.svelte.ejs
@@ -1,0 +1,61 @@
+<script>
+	import { onMount } from 'svelte'
+	import { page } from '$app/stores'
+	import { goto } from '$app/navigation'
+	import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft.js'
+
+	import <%= entityInstance %>Service from '$lib/entities/<%= entityFolderName %>/<%= entityInstance %>-service.js'
+	import Page from '$lib/page/Page.svelte'
+	import Record from '$lib/page/Record.svelte'
+	import Button from '$lib/Button.svelte'
+	import Icon from '$lib/Icon.svelte'
+
+	$: id = $page && $page.params && $page.params.id
+	onMount(() => fetch<%= entityAngularName %>Details())
+
+	let error
+	let <%= entityInstance %>
+
+	function fetch<%= entityAngularName %>Details() {
+		error = undefined
+		<%= entityInstance %>Service
+			.findById(id)
+			.then(res => (<%= entityInstance %> = res))
+			.catch(err => (error = err))
+	}
+</script>
+
+<svelte:head>
+	<title><%= entityClassHumanized %> Details</title>
+	<meta name="Description" content="<%= entityClassHumanized %> details" />
+</svelte:head>
+<Page testId="<%= entityInstance %>Mgmt" width="full">
+	<div class="text-left" slot="header">
+		<%= entityClassHumanized %> Details
+	</div>
+	{#if <%= entityInstance %>}
+		<div class="mt-4 table table-auto w-full">
+<%_
+	let isFirstRecord = true
+	for (field of fields.filter(field => !field.id)) {
+_%>
+			<Record<% if(isFirstRecord) { %> classes="border-t"<% } %>>
+				<span slot="label"><%= field.fieldNameHumanized %></span>
+				<span>{<%= entityInstance %>.<%= field.fieldName %>}</span>
+			</Record>
+<%_
+		isFirstRecord = false
+	}
+_%>
+		</div>
+	{/if}
+	<div class="flex mt-4 flex-row justify-center items-center leading-none">
+		<Button
+			name="backBtn"
+			on:click="{() => goto(`/entities/<%= entityFolderName %>`)}"
+		>
+			<Icon classes="mr-2" icon="{faArrowLeft}" />
+			Back
+		</Button>
+	</div>
+</Page>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/index.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/index.svelte.ejs
@@ -1,0 +1,148 @@
+<script>
+	import { onMount } from 'svelte'
+	import { goto } from '$app/navigation'
+	import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus.js'
+
+	import auth from '$lib/auth/auth-store.js'
+	import <%= entityInstance %>Service from '$lib/entities/<%= entityFolderName %>/<%= entityInstance %>-service.js'
+	import Page from '$lib/page/Page.svelte'
+	import Button from '$lib/Button.svelte'
+	import Icon from '$lib/Icon.svelte'
+<%_ if (!paginationNo) { _%>
+	import Pagination from '$lib/table/Pagination.svelte'
+<%_ } _%>
+	import <%= entityAngularName %>Table from '$lib/entities/<%= entityFolderName %>/<%= entityAngularName %>Table.svelte'
+	import <%= entityAngularName %>DeleteModal from '$lib/entities/<%= entityFolderName %>/<%= entityAngularName %>DeleteModal.svelte'
+
+	let error
+	let <%= entityInstancePlural %> = []
+<%_ if (!paginationNo) { _%>
+	let sortPredicate = 'id'
+	let sortOrder = 'asc'
+	let pageSize = 15
+	let page = 1
+	let totalCount = 0
+<%_ } _%>
+	let loading = true
+	let showDeleteModal = false
+	let <%= entityInstance %>Id = null
+
+	onMount(() => fetch<%= entityClassPluralHumanized %>())
+
+	function fetch<%= entityClassPluralHumanized %>() {
+		loading = true
+		error = undefined
+		<%= entityInstance %>Service
+			.findAll(<% if (!paginationNo) { %>page, pageSize, sortPredicate, sortOrder<% } %>)
+			.then(res => {
+			<%_ if (!paginationNo) { _%>
+				<%= entityInstancePlural %> = res.data
+				totalCount = res.totalCount
+			<%_ } else { _%>
+				<%= entityInstancePlural %> = res
+			<%_ } _%>
+			})
+			.catch(err => (error = err))
+			.finally((loading = false))
+	}
+
+	function view<%= entityAngularName %>(event) {
+		goto(`/entities/<%= entityFolderName %>/${event.detail.id}/view`)
+	}
+
+	function update<%= entityAngularName %>(event) {
+		goto(`/entities/<%= entityFolderName %>/${event.detail.id}/edit`)
+	}
+
+	function showDelete<%= entityAngularName %>Modal(event) {
+		<%= entityInstance %>Id = event.detail.id
+		showDeleteModal = true
+	}
+
+	function closeDelete<%= entityAngularName %>Modal() {
+		showDeleteModal = false
+		<%= entityInstance %>Id = null
+	}
+
+	function delete<%= entityAngularName %>(event) {
+		<%= entityInstance %>Service
+			.delete(<%= entityInstance %>Id)
+			.then(() => fetch<%= entityClassPluralHumanized %>())
+			.catch(err => (error = err))
+			.finally(() => (showDeleteModal = false), (<%= entityInstance %>Id = null))
+	}
+<%_ if (!paginationNo) { _%>
+	function sortByPredicate(event) {
+		sortPredicate = event.detail.sortPredicate
+		sortOrder = event.detail.sortOrder
+		fetch<%= entityClassPluralHumanized %>()
+	}
+
+	function handlePageChange(event) {
+		page = event.detail.page
+		fetch<%= entityClassPluralHumanized %>()
+	}
+<%_ } _%>
+</script>
+
+<svelte:head>
+	<title><%= entityClassPluralHumanized %></title>
+	<meta name="Description" content="<%= entityAngularName %> list" />
+</svelte:head>
+
+<Page testId="<%= entityInstance %>ListPage" width="full">
+	<div
+		class="text-left flex flex-row justify-between items-center"
+		slot="header"
+	>
+		<span><%= entityClassPluralHumanized %></span>
+		<div class="flex flex-row justify-end text-base">
+			<Button
+				classes="sm:my-0"
+				disabled="disabled"
+				on:click="{() => goto(`/entities/<%= entityFolderName %>/new`)}"
+			>
+				<Icon classes="mr-2" icon="{faPlus}" />
+				Create <%= entityClassHumanized %>
+			</Button>
+		</div>
+	</div>
+	{#if !loading && <%= entityInstancePlural %>.length}
+		{#if showDeleteModal}
+			<<%= entityAngularName %>DeleteModal
+				id="{<%= entityInstance %>Id}"
+				on:close="{closeDelete<%= entityAngularName %>Modal}"
+				on:delete<%= entityAngularName %>="{delete<%= entityAngularName %>}"
+			/>
+		{/if}
+
+<%_ if (!paginationNo) { _%>
+		<Pagination
+			totalCount="{totalCount}"
+			pageSize="{pageSize}"
+			page="{page}"
+			classes="my-2"
+			on:pagechange="{handlePageChange}"
+		/>
+<%_ } _%>
+		<<%= entityAngularName %>Table
+			<%= entityInstancePlural %>="{<%= entityInstancePlural %>}"
+		<%_ if (!paginationNo) { _%>
+			sortPredicate="{sortPredicate}"
+			on:sortbypredicate="{sortByPredicate}"
+		<%_ } _%>
+			on:update<%= entityInstance %>="{update<%= entityAngularName %>}"
+			on:view<%= entityInstance %>="{view<%= entityAngularName %>}"
+			on:delete<%= entityInstance %>="{showDelete<%= entityAngularName %>Modal}"
+		/>
+<%_ if (!paginationNo) { _%>
+		<Pagination
+			totalCount="{totalCount}"
+			pageSize="{pageSize}"
+			page="{page}"
+			classes="mt-4"
+			on:pagechange="{handlePageChange}"
+		/>
+<%_ } _%>
+	{/if}
+</Page>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/index.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/index.svelte.ejs
@@ -90,7 +90,7 @@
 	<meta name="Description" content="<%= entityAngularName %> list" />
 </svelte:head>
 
-<Page testId="<%= entityInstance %>ListPage" width="full">
+<Page testId="<%= entityInstance %>" width="full">
 	<div
 		class="text-left flex flex-row justify-between items-center"
 		slot="header"

--- a/generators/util.js
+++ b/generators/util.js
@@ -1,0 +1,29 @@
+const jhipsterUtils = require('generator-jhipster/generators/utils');
+const constants = require('generator-jhipster/generators/generator-constants');
+
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+
+module.exports = {
+	addEntityToMenu,
+};
+
+function addEntityToMenu(generator, entityRoute, entityName, entityClass) {
+	jhipsterUtils.rewriteFile(
+		{
+			file: `${CLIENT_MAIN_SRC_DIR}/app/lib/layout/EntityMenu.svelte`,
+			needle: 'jhipster-needle-add-entity-to-menu',
+			splicable: [
+				// prettier-ignore
+				`\t\t<MenuItem
+\t\t\ttestId="svl${entityClass}MgmtLink"
+\t\t\tlink="/entities/${entityRoute}"
+\t\t\ton:click="{() => (isOpen = false)}"
+\t\t>
+\t\t\t<Icon classes="sm:mr-1" icon="{faAsterisk}" />
+\t\t\t${entityName}
+\t\t</MenuItem>`,
+			],
+		},
+		generator
+	);
+}


### PR DESCRIPTION
Closes #470 

---

- Generate entity `list`, `view` and `delete` dialog pages
- Cypress `e2e` tests
- Supports `pagination`
- Entity `JDL` supports simple string data type fields.

## Sample JDL
```
application {
    config {
        baseName SampleBlogApp,
        applicationType monolith,
        authenticationType jwt,
        packageName tech.jhipster.samples.blog,
        databaseType mongodb,
        cacheProvider caffeine,
        buildTool maven
    }
    entities *
}

entity Blog {
  name String required minlength(5)
  handle String required minlength(2)
}

entity Tag {
  name String required minlength(3)
}

paginate Tag with pagination
```