### PR TITLE
feat: Support client-side pagination, use in loggers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ## [Unreleased]
 
+### Added
+
+-   ✅ `PaginatedTable` component to encapsulate pagination and sort events, client-side pagination [#557](https://github.com/jhipster/generator-jhipster-svelte/pull/557)
+
+### Changed
+
+-   ✅ Client-side pagination support in the `Logger` page [#557](https://github.com/jhipster/generator-jhipster-svelte/pull/557)
+
+### Fixed
+
+-   ✅ Fix an issue to apply filter criteria after an update of logger level on the selected page [#557](https://github.com/jhipster/generator-jhipster-svelte/pull/557)
+
 ## [0.5.0] - 2021-07-07
 
 ### BREAKING CHANGES

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -173,6 +173,7 @@ const svelteFiles = {
 				'notification/notification-store.js',
 				'notification/Notification.svelte',
 				'notification/Toast.svelte',
+				'table/PaginatedTable.svelte',
 				'table/Pagination.svelte',
 				'table/Sort.svelte',
 				'table/Table.svelte',

--- a/generators/client/templates/svelte/cypress/integration/admin/logger.spec.js.ejs
+++ b/generators/client/templates/svelte/cypress/integration/admin/logger.spec.js.ejs
@@ -33,9 +33,15 @@ describe('Loggers page', () => {
 	})
 
 	it('should display logger name and the default enabled logger level in the table', () => {
+
+<%_	if (databaseTypeSql) { _%>
+		cy.getBySel('loggerSearchForm').getByName('logger').type('org.hibernate.Version')
+<%_ } else { _%>
+		cy.getBySel('loggerSearchForm').getByName('logger').type('org.mongodb.driver')
+<%_ } _%>
+
 		cy.getBySel('loggersTable')
-<%_
-	if (databaseTypeSql) { _%>
+<%_	if (databaseTypeSql) { _%>
 			.contains('td', 'org.hibernate.Version')
 <%_ } else { _%>
 			.contains('td', 'org.mongodb.driver')
@@ -69,6 +75,12 @@ describe('Loggers page', () => {
 	})
 
 	it('should display actions available on the current selected logger', () => {
+<%_	if (databaseTypeSql) { _%>
+		cy.getBySel('loggerSearchForm').getByName('logger').type('org.hibernate.Version')
+<%_ } else { _%>
+		cy.getBySel('loggerSearchForm').getByName('logger').type('org.mongodb.driver')
+<%_ } _%>
+
 		cy.getBySel('loggersTable')
 <%_
 	if (databaseTypeSql) { _%>
@@ -106,6 +118,11 @@ describe('Loggers page', () => {
 	})
 
 	it('should change logger level from WARN -> INFO, INFO -> WARN', () => {
+<%_	if (databaseTypeSql) { _%>
+		cy.getBySel('loggerSearchForm').getByName('logger').type('org.hibernate.Version')
+<%_ } else { _%>
+		cy.getBySel('loggerSearchForm').getByName('logger').type('org.mongodb.driver')
+<%_ } _%>
 
 		cy.intercept('**/management/loggers/*').as('changeLoggers')
 
@@ -157,7 +174,7 @@ describe('Loggers page', () => {
 		let countBeforeFilter
 
 		cy.getBySel('loggersTable')
-			.get('tr')
+			.get('tbody > tr')
 			.then($tr => (countBeforeFilter = $tr.length))
 
 		cy.getBySel('loggerSearchForm')
@@ -165,7 +182,29 @@ describe('Loggers page', () => {
 			.type('ROOT');
 
 		cy.getBySel('loggersTable')
-			.get('tr')
+			.get('tbody > tr')
 			.then($tr => (expect($tr.length).not.eq(countBeforeFilter)))
+
+		cy.getBySel('loggerSearchForm').getByName('logger').clear()
+
+		cy.getBySel('loggersTable')
+			.get('tbody > tr')
+			.then($tr => expect($tr.length).eq(countBeforeFilter))
+	})
+
+	it('should validate the pagination controls', () => {
+		cy.getBySel('pageCtrl')
+			.eq(0)
+			.contains('div', /1-\d+ of \d+/)
+			.next()
+			.within($div => {
+				cy.root()
+					.getBySel('prevPageCtrl')
+					.should('be.disabled')
+					.get('div')
+					.should('have.text', '1')
+					.getBySel('nextPageCtrl')
+					.should('be.enabled')
+			})
 	})
 })

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/table/PaginatedTable.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/table/PaginatedTable.svelte.ejs
@@ -1,0 +1,87 @@
+<script>
+	import { createEventDispatcher, onMount } from 'svelte'
+
+	import Pagination from '$lib/table/Pagination.svelte'
+
+	export let component
+	export let clientSidePagination = false
+	export let paginationKey
+	export let page = 1
+	export let pageSize = 15
+	export let sortOrder = 'asc'
+	export let sortPredicate = 'id'
+	export let totalCount = 0
+	export let props
+	export let events
+
+	let paginatedRecords
+	let paginatedProps
+	let instance
+	const dispatch = createEventDispatcher()
+
+	function fetchRecords() {
+		dispatch('fetch', { page, pageSize, sortPredicate, sortOrder })
+	}
+
+	function sortByPredicate(event) {
+		sortPredicate = event.detail.sortPredicate
+		sortOrder = event.detail.sortOrder
+		if (!(clientSidePagination && paginationKey)) {
+			fetchRecords()
+		}
+	}
+
+	function handlePageChange(event) {
+		page = event.detail.page
+		if (!(clientSidePagination && paginationKey)) {
+			fetchRecords()
+		} else {
+			dispatch('pagechange', { page, pageSize })
+		}
+	}
+
+	$: if (instance && events) {
+		for (let eventKey of events) {
+			instance.$on(eventKey, event => {
+				dispatch(eventKey, { ...event.detail })
+			})
+		}
+	}
+
+	$: {
+		if (clientSidePagination && paginationKey) {
+			const pageStart = totalCount === 0 ? 0 : (page - 1) * pageSize
+			const pageEnd =
+				page * pageSize > totalCount ? totalCount : page * pageSize
+			const paginatedRecords = props[paginationKey].slice(
+				pageStart,
+				pageEnd
+			)
+			paginatedProps = { ...props, [paginationKey]: paginatedRecords }
+		} else {
+			paginatedProps = props
+		}
+	}
+</script>
+
+<Pagination
+	totalCount="{totalCount}"
+	pageSize="{pageSize}"
+	page="{page}"
+	classes="my-2"
+	on:pagechange="{handlePageChange}"
+/>
+<svelte:component
+	this="{component}"
+	sortPredicate="{sortPredicate}"
+	{...paginatedProps}
+	on:sortbypredicate="{sortByPredicate}"
+	bind:this="{instance}"
+/>
+<Pagination
+	totalCount="{totalCount}"
+	pageSize="{pageSize}"
+	page="{page}"
+	classes="mt-4"
+	on:pagechange="{handlePageChange}"
+/>

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/admin/user-management/index.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/admin/user-management/index.svelte.ejs
@@ -8,7 +8,7 @@
 	import Page from '$lib/page/Page.svelte'
 	import Button from '$lib/Button.svelte'
 	import Icon from '$lib/Icon.svelte'
-	import Pagination from '$lib/table/Pagination.svelte'
+	import PaginatedTable from '$lib/table/PaginatedTable.svelte'
 	import UserTable from '$lib/admin/user-management/UserTable.svelte'
 	import UserDeleteModal from '$lib/admin/user-management/UserDeleteModal.svelte'
 
@@ -63,7 +63,7 @@
 		userId = null
 	}
 
-	function deleteUserAccount(event) {
+	function deleteUserAccount() {
 		userService
 			.delete(userId)
 			.then(() => fetchUsers())
@@ -71,14 +71,9 @@
 			.finally(() => (showDeleteModal = false), (userId = null))
 	}
 
-	function sortByPredicate(event) {
-		sortPredicate = event.detail.sortPredicate
-		sortOrder = event.detail.sortOrder
-		fetchUsers()
-	}
-
-	function handlePageChange(event) {
-		page = event.detail.page
+	function handleFetch(event) {
+		// eslint-disable-next-line no-extra-semi
+		;({ page, pageSize, sortPredicate, sortOrder } = event.detail)
 		fetchUsers()
 	}
 </script>
@@ -113,29 +108,25 @@
 			/>
 		{/if}
 
-		<Pagination
-			totalCount="{totalCount}"
-			pageSize="{pageSize}"
+		<PaginatedTable
+			component="{UserTable}"
 			page="{page}"
-			classes="my-2"
-			on:pagechange="{handlePageChange}"
-		/>
-		<UserTable
-			users="{users}"
-			currentUser="{$auth}"
+			pageSize="{pageSize}"
+			sortOrder="{sortOrder}"
 			sortPredicate="{sortPredicate}"
-			on:sortbypredicate="{sortByPredicate}"
+			totalCount="{totalCount}"
+			props="{{ users: users, currentUser: $auth }}"
+			events="{[
+				'toggleuseraccount',
+				'viewuseraccount',
+				'updateuseraccount',
+				'deleteuseraccount',
+			]}"
+			on:fetch="{handleFetch}"
 			on:toggleuseraccount="{toggleUserAccount}"
 			on:updateuseraccount="{updateUserAccount}"
 			on:viewuseraccount="{viewUserAccount}"
 			on:deleteuseraccount="{showDeleteUserModal}"
-		/>
-		<Pagination
-			totalCount="{totalCount}"
-			pageSize="{pageSize}"
-			page="{page}"
-			classes="mt-4"
-			on:pagechange="{handlePageChange}"
 		/>
 	{/if}
 </Page>


### PR DESCRIPTION
Closes #464 

---
- Add a new `PaginatedTable` component to encapsulate pagination control functionality
- Support client-side pagination and use of new component in `Loggers` page
- Replace the direct use of pagination controls in the user management page with the new `PaginatedTable` component
- Fix an issue in the `Logger` page to retain filter criteria after a call to update logger levels.