### PR TITLE
feat: Support date data type and integrate date-fns lib

### DIFF
--- a/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
@@ -14,6 +14,7 @@ application {
 entity Blog {
   name String required minlength(5)
   handle String required minlength(2)
+  date Instant required
 }
 
 entity Tag {

--- a/.github/workflows/scripts/monolithic-jwt-maven-skip-user.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-skip-user.jdl
@@ -15,6 +15,7 @@ application {
 entity Blog {
   name String required minlength(5)
   handle String required minlength(2)
+  date Instant required
 }
 
 entity Tag {

--- a/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
+++ b/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
@@ -15,6 +15,7 @@ application {
 entity Blog {
   name String required minlength(5)
   handle String required minlength(2)
+  date Instant required
 }
 
 entity Tag {

--- a/.github/workflows/scripts/monolithic-session-maven.jdl
+++ b/.github/workflows/scripts/monolithic-session-maven.jdl
@@ -14,6 +14,7 @@ application {
 entity Blog {
   name String required minlength(5)
   handle String required minlength(2)
+  date Instant required
 }
 
 entity Tag {

--- a/.github/workflows/scripts/svelte-app-session-lighthouse.jdl
+++ b/.github/workflows/scripts/svelte-app-session-lighthouse.jdl
@@ -14,6 +14,7 @@ application {
 
 entity Tag {
   name String required minlength(3)
+  date Instant required
 }
 
 paginate Tag with pagination

--- a/generators/client/templates/svelte/package.json
+++ b/generators/client/templates/svelte/package.json
@@ -1,4 +1,7 @@
 {
+	"dependencies": {
+		"date-fns": "2.23.0"
+	},
 	"devDependencies": {
 		"@fortawesome/free-solid-svg-icons": "5.15.4",
 		"@sveltejs/adapter-static": "1.0.0-next.18",

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/admin/user-management/UserTable.spec.js.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/admin/user-management/UserTable.spec.js.ejs
@@ -130,7 +130,7 @@ test('should render table data for inactive user', () => {
 		screen.getByRole('cell', { name: /ROLE_ADMIN, ROLE_USER/i })
 	).toBeInTheDocument()
 	expect(
-		screen.getByRole('cell', { name: /4\/11\/2011/i })
+		screen.getByRole('cell', { name: /over \d+ years ago$/i })
 	).toBeInTheDocument()
 	expect(screen.getByRole('cell', { name: /^admin$/i })).toBeInTheDocument()
 	expect(screen.getByRole('cell', { name: /-/i })).toBeInTheDocument()

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/admin/user-management/UserTable.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/admin/user-management/UserTable.svelte.ejs
@@ -5,7 +5,7 @@
 	import TableData from '$lib/table/TableData.svelte'
 	import TableHeader from '$lib/table/TableHeader.svelte'
 	import TableRow from '$lib/table/TableRow.svelte'
-	import { formatDate } from '$lib/utils/date'
+	import { formatDistance } from '$lib/utils/date'
 
 	export let users = []
 	export let currentUser = null
@@ -63,11 +63,11 @@
 				<TableData>
 					<span class="uppercase">{user.authorities.join(', ')}</span>
 				</TableData>
-				<TableData>{formatDate(user.createdDate)}</TableData>
+				<TableData>{formatDistance(user.createdDate)}</TableData>
 				<TableData>{user.lastModifiedBy}</TableData>
 				<TableData classes="w-48 {showActions ? 'sm:py-0' : ''}">
 					<div class:hidden="{showActions}">
-						{formatDate(user.lastModifiedDate)}
+						{formatDistance(user.lastModifiedDate)}
 					</div>
 					<UserListActions
 						currentUser="{currentUser.login}"

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/table/Pagination.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/table/Pagination.svelte.ejs
@@ -26,7 +26,7 @@
 </script>
 
 <div
-	class="flex flex-row justify-end items-center {classes}"
+	class="flex flex-row justify-end items-center w-full {classes}"
 	data-test="pageCtrl"
 >
 	<div>{pageStart}-{pageEnd} of {totalCount}</div>

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/utils/date.js.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/utils/date.js.ejs
@@ -1,15 +1,9 @@
-export function formatDate(dateToFormat) {
-	if (dateToFormat) {
-		const date = new Date(Date.parse(dateToFormat))
-		return date.toLocaleDateString('en-US', {
-			hour12: false,
-			year: 'numeric',
-			month: 'numeric',
-			day: 'numeric',
-			hour: 'numeric',
-			minute: 'numeric',
-		})
-	}
+import { format, formatDistanceToNow } from 'date-fns'
 
-	return '-'
+export function formatDate(dateToFormat) {
+	return dateToFormat ? format(new Date(Date.parse(dateToFormat)), 'MM/dd/yyyy HH:mm') : '-'
+}
+
+export function formatDistance(dateToFormat) {
+	return dateToFormat ? formatDistanceToNow(new Date(Date.parse(dateToFormat)), {addSuffix: true}) : '-'
 }

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -14,7 +14,11 @@ describe('<%= entityAngularName %> delete dialog page', () => {
 		<%_
 			for (field of fields.filter(field => !field.id)) {
 		_%>
+		<%_ if (field.fieldTypeTimed) { _%>
+			<%= field.fieldName %>: new Date(),
+		<%_ } else { _%>
 			<%= field.fieldName %>: randomPrefix,
+		<%_ } _%>
 		<%_ } _%>
 		}).then(res => {
 			dynamicId = res.id

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -18,7 +18,11 @@ describe('<%= entityAngularName %> list page', () => {
 		<%_
 			for (field of fields.filter(field => !field.id)) {
 		_%>
+			<%_ if (field.fieldTypeTimed) { _%>
+			<%= field.fieldName %>: new Date(),
+			<%_ } else { _%>
 			<%= field.fieldName %>: randomPrefix2,
+			<%_ } _%>
 		<%_ } _%>
 		}).then(res => {
 			dynamicId2 = res.id
@@ -29,7 +33,11 @@ describe('<%= entityAngularName %> list page', () => {
 		<%_
 			for (field of fields.filter(field => !field.id)) {
 		_%>
+			<%_ if (field.fieldTypeTimed) { _%>
+			<%= field.fieldName %>: new Date(),
+			<%_ } else { _%>
 			<%= field.fieldName %>: randomPrefix,
+			<%_ } _%>
 		<%_ } _%>
 		}).then(res => {
 			dynamicId = res.id

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -14,7 +14,11 @@ describe('<%= entityAngularName %> view details page', () => {
 		<%_
 			for (field of fields.filter(field => !field.id)) {
 		_%>
+			<%_ if (field.fieldTypeTimed) { _%>
+			<%= field.fieldName %>: new Date(),
+			<%_ } else { _%>
 			<%= field.fieldName %>: randomPrefix,
+			<%_ } _%>
 		<%_ } _%>
 		}).then(res => {
 			dynamicId = res.id

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityTable.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/lib/entities/entity/EntityTable.svelte.ejs
@@ -5,7 +5,10 @@
 	import TableData from '$lib/table/TableData.svelte'
 	import TableHeader from '$lib/table/TableHeader.svelte'
 	import TableRow from '$lib/table/TableRow.svelte'
-
+<%_ const timedFieldType = fields.find(field => field.fieldTypeTimed);
+	if (timedFieldType) { _%>
+	import { formatDate } from '$lib/utils/date'
+<%_ } _%>
 	export let <%= entityInstancePlural %> = []
 <%_ if (!paginationNo) { _%>
 	export let sortPredicate = 'id'
@@ -49,7 +52,11 @@
 			<%_
 				for (field of fields.filter(field => !field.id)) {
 			_%>
+				<%_ if (field.fieldTypeTimed) { _%>
+				<TableData>{formatDate(<%=entityInstance %>.<%= field.fieldName %>)}</TableData>
+				<%_ } else { _%>
 				<TableData>{<%=entityInstance %>.<%= field.fieldName %>}</TableData>
+				<%_ } _%>
 			<%_ } _%>
 				<TableData classes="w-48 {showActions ? 'sm:py-0' : ''}">
 					<div class:hidden="{showActions}">&nbsp;</div>

--- a/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/[id]/view.svelte.ejs
+++ b/generators/entity-client/templates/svelte/src/main/webapp/app/routes/entities/entity/[id]/view.svelte.ejs
@@ -9,6 +9,10 @@
 	import Record from '$lib/page/Record.svelte'
 	import Button from '$lib/Button.svelte'
 	import Icon from '$lib/Icon.svelte'
+<%_ const timedFieldType = fields.find(field => field.fieldTypeTimed);
+	if (timedFieldType) { _%>
+	import { formatDate } from '$lib/utils/date'
+<%_ } _%>
 
 	$: id = $page && $page.params && $page.params.id
 	onMount(() => fetch<%= entityAngularName %>Details())
@@ -39,7 +43,11 @@
 _%>
 			<Record<% if(isFirstRecord) { %> classes="border-t"<% } %>>
 				<span slot="label"><%= field.fieldNameHumanized %></span>
+				<%_ if (field.fieldTypeTimed) { _%>
+				<span>{formatDate(<%= entityInstance %>.<%= field.fieldName %>)}</span>
+				<%_ } else { _%>
 				<span>{<%= entityInstance %>.<%= field.fieldName %>}</span>
+				<%_ } _%>
 			</Record>
 <%_
 		isFirstRecord = false


### PR DESCRIPTION
Closes #521 
Related #527 

---
- Use `date-fns` library to support date manipulations
- Update user management list page to display date in distance format
- Support `Instant` date data type support in the list, view pages