### PR TITLE
Refactor and improve relationship support in cypress tests

### DIFF
--- a/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
@@ -49,7 +49,7 @@ entity SampleEntity {
 }
 
 relationship OneToOne {
-  SampleBlobEntity{user(login)} to User
+  SampleBlobEntity{user(login)} to SampleEntity
 }
 
 relationship OneToMany {

--- a/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
@@ -49,7 +49,7 @@ entity SampleEntity {
 }
 
 relationship OneToOne {
-  SampleBlobEntity{user(login)} to SampleEntity
+  SampleBlobEntity{sampleEntity(name)} to SampleEntity
 }
 
 relationship OneToMany {

--- a/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
+++ b/.github/workflows/scripts/monolithic-jwt-maven-mongodb-prod.jdl
@@ -16,17 +16,23 @@ application {
  }
 
 entity SampleDomainEntity {
+  localDateData	LocalDate
+  zonedDateTimeData ZonedDateTime
+  instantData Instant
+  durationData Duration
+}
+
+entity SampleDomainEntityTwo {
   stringData String required minlength(5) maxlength(50)
   integerData Integer required min(2) max(1000)
   longData Long required min(2) max(4000)
   bigDecimalData BigDecimal required
   floatData Float
+}
+
+entity SampleDomainEntityThree {
   doubleData Double
   booleanData Boolean
-  localDateData	LocalDate
-  zonedDateTimeData ZonedDateTime
-  instantData Instant
-  durationData Duration
   uuidData UUID
   enumData EntityStatus
 }
@@ -36,6 +42,24 @@ entity SampleBlobEntity {
   anyBlobData AnyBlob
   imageBlobData ImageBlob
   textBlobData TextBlob
+}
+
+entity SampleEntity {
+  name String
+}
+
+relationship OneToOne {
+  SampleBlobEntity{user(login)} to User
+}
+
+relationship OneToMany {
+  SampleBlobEntity{domainEntity} to SampleDomainEntityTwo{blobEntity(textBlobData)},
+}
+relationship ManyToOne {
+  SampleDomainEntityThree{user(login)} to User
+}
+relationship ManyToMany {
+  SampleDomainEntity{sampleEntity(name)} to SampleEntity{sampleDomainEntity}
 }
 
 paginate SampleDomainEntity with pagination

--- a/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
+++ b/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
@@ -51,7 +51,7 @@ entity SampleEntity {
 }
 
 relationship OneToOne {
-  SampleBlobEntity{user(login)} to User
+  SampleBlobEntity{user(login)} to SampleEntity
 }
 
 relationship OneToMany {

--- a/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
+++ b/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
@@ -12,22 +12,29 @@ application {
     entities *
 }
 
+
  enum EntityStatus {
     DUMMY, APP, SVELTE
  }
 
 entity SampleDomainEntity {
+  localDateData	LocalDate
+  zonedDateTimeData ZonedDateTime
+  instantData Instant
+  durationData Duration
+}
+
+entity SampleDomainEntityTwo {
   stringData String required minlength(5) maxlength(50)
   integerData Integer required min(2) max(1000)
   longData Long required min(2) max(4000)
   bigDecimalData BigDecimal required
   floatData Float
+}
+
+entity SampleDomainEntityThree {
   doubleData Double
   booleanData Boolean
-  localDateData	LocalDate
-  zonedDateTimeData ZonedDateTime
-  instantData Instant
-  durationData Duration
   uuidData UUID
   enumData EntityStatus
 }
@@ -39,5 +46,22 @@ entity SampleBlobEntity {
   textBlobData TextBlob
 }
 
-paginate SampleDomainEntity with pagination
+entity SampleEntity {
+  name String
+}
 
+relationship OneToOne {
+  SampleBlobEntity{user(login)} to User
+}
+
+relationship OneToMany {
+  SampleBlobEntity{domainEntity} to SampleDomainEntityTwo{blobEntity(textBlobData)},
+}
+relationship ManyToOne {
+  SampleDomainEntityThree{user(login)} to User
+}
+relationship ManyToMany {
+  SampleDomainEntity{sampleEntity(name)} to SampleEntity{sampleDomainEntity}
+}
+
+paginate SampleDomainEntity with pagination

--- a/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
+++ b/.github/workflows/scripts/monolithic-oidc-maven-postgres-prod.jdl
@@ -51,7 +51,7 @@ entity SampleEntity {
 }
 
 relationship OneToOne {
-  SampleBlobEntity{user(login)} to SampleEntity
+  SampleBlobEntity{sampleEntity(name)} to SampleEntity
 }
 
 relationship OneToMany {

--- a/.github/workflows/scripts/monolithic-session-maven.jdl
+++ b/.github/workflows/scripts/monolithic-session-maven.jdl
@@ -11,22 +11,29 @@ application {
     entities *
 }
 
+
  enum EntityStatus {
     DUMMY, APP, SVELTE
  }
 
 entity SampleDomainEntity {
+  localDateData	LocalDate
+  zonedDateTimeData ZonedDateTime
+  instantData Instant
+  durationData Duration
+}
+
+entity SampleDomainEntityTwo {
   stringData String required minlength(5) maxlength(50)
   integerData Integer required min(2) max(1000)
   longData Long required min(2) max(4000)
   bigDecimalData BigDecimal required
   floatData Float
+}
+
+entity SampleDomainEntityThree {
   doubleData Double
   booleanData Boolean
-  localDateData	LocalDate
-  zonedDateTimeData ZonedDateTime
-  instantData Instant
-  durationData Duration
   uuidData UUID
   enumData EntityStatus
 }
@@ -36,6 +43,24 @@ entity SampleBlobEntity {
   anyBlobData AnyBlob
   imageBlobData ImageBlob
   textBlobData TextBlob
+}
+
+entity SampleEntity {
+  name String
+}
+
+relationship OneToOne {
+  SampleBlobEntity{user(login)} to User
+}
+
+relationship OneToMany {
+  SampleBlobEntity{domainEntity} to SampleDomainEntityTwo{blobEntity(textBlobData)},
+}
+relationship ManyToOne {
+  SampleDomainEntityThree{user(login)} to User
+}
+relationship ManyToMany {
+  SampleDomainEntity{sampleEntity(name)} to SampleEntity{sampleDomainEntity}
 }
 
 paginate SampleDomainEntity with pagination

--- a/.github/workflows/scripts/monolithic-session-maven.jdl
+++ b/.github/workflows/scripts/monolithic-session-maven.jdl
@@ -50,7 +50,7 @@ entity SampleEntity {
 }
 
 relationship OneToOne {
-  SampleBlobEntity{user(login)} to SampleEntity
+  SampleBlobEntity{sampleEntity(name)} to SampleEntity
 }
 
 relationship OneToMany {

--- a/.github/workflows/scripts/monolithic-session-maven.jdl
+++ b/.github/workflows/scripts/monolithic-session-maven.jdl
@@ -50,7 +50,7 @@ entity SampleEntity {
 }
 
 relationship OneToOne {
-  SampleBlobEntity{user(login)} to User
+  SampleBlobEntity{user(login)} to SampleEntity
 }
 
 relationship OneToMany {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 > All notable changes to the "generator-jhipster-svelte" project will be documented in this file.
 
+## Current
+
+### Added
+
+-   ✅ JHipster entity `JDL` supporting `Create`, `Update` pages along with `Cypress` e2e tests [#786](https://github.com/jhipster/generator-jhipster-svelte/pull/786), [#792](https://github.com/jhipster/generator-jhipster-svelte/pull/792), [#804](https://github.com/jhipster/generator-jhipster-svelte/pull/804), [#812](https://github.com/jhipster/generator-jhipster-svelte/pull/812), [#822](https://github.com/jhipster/generator-jhipster-svelte/pull/822), [#823](https://github.com/jhipster/generator-jhipster-svelte/pull/823)
+-   ✅ JHipster relationship `JDL` supporting `one-to-one`, `one-to-many`, `many-to-one`, and `many-to-many` relationships along with `Cypress` e2e tests [#824](https://github.com/jhipster/generator-jhipster-svelte/pull/824), [#866](https://github.com/jhipster/generator-jhipster-svelte/pull/866)
+-   ✅ Use `cypress` session API to improve e2e tests performance [#753](https://github.com/jhipster/generator-jhipster-svelte/pull/753)
+
+### Changed
+
+-   ✅ Bump `JHipster` dependency to support `7.4.1` release [#800](https://github.com/jhipster/generator-jhipster-svelte/pull/800), [#852](https://github.com/jhipster/generator-jhipster-svelte/pull/852)
+-   ✅ Bump `Tailwind` dependency to support `3.0.x` release [#852](https://github.com/jhipster/generator-jhipster-svelte/pull/852)
+-   ✅ Regular maintenance to bump `Cypress`, `svelte`, `svelte/kit`, `eslint` etc dependencies
+
 ## [0.6.0] - 2021-10-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Following integrations are supported:
     ✅ Cypress integration for end to end tests
     ✅ Jest and Testing Library integration for unit tests
     ✅ JHipster application JDL
-    ✅ JHipster entity JDL (simple data type, no relation)
+    ✅ JHipster entity JDL
     ✅ JHipster elasticsearch integration
 
 Following functional flows are covered with end to end tests:
@@ -43,7 +43,7 @@ Following functional flows are covered with end to end tests:
         ✅ User Management (List, Create, Update, View, Delete)
         ✅ Loggers
     ✅ Entities
-        ✅ Entity (List, View, Delete, Search, Pagination)
+        ✅ Entity (List, Create, Update, View, Delete, Search, Pagination)
 
 For more details, you can check out the source code of [sample application](https://github.com/jhipster/jhipster-sample-app-svelte)
 
@@ -108,10 +108,19 @@ npm update -g generator-jhipster-svelte
         name String required minlength(3)
     }
 
+    relationship ManyToOne {
+        Blog{user(login)} to User
+        Post{blog(name)} to Blog
+    }
+
+    relationship ManyToMany {
+        Post{tag(name)} to Tag{entry}
+    }
+
     paginate Tag with pagination
     ```
 
-    Refer to [JDL entity fields](https://www.jhipster.tech/jdl/entities-fields) documentation for all supported entity data types and constraints.
+    Refer to [JDL entity fields](https://www.jhipster.tech/jdl/entities-fields) documentation for all supported entity data types and constraints. Refer to [JDL relationships](https://www.jhipster.tech/managing-relationships/) documentation for supported relationships and syntax.
 
     Pass `import-jdl` option along the file path to `shipster` cli to generate new application:
 
@@ -132,7 +141,8 @@ npm update -g generator-jhipster-svelte
 | `6.10.5`   | `0.1` - `0.2.1`  |
 | `7.0.x`    | `0.3` - `0.4`    |
 | `7.1.x`    | `0.5`            |
-| `7.3.x`    | >= `0.6`         |
+| `7.3.x`    | `0.6`            |
+| `7.4.x`    | >= `0.7`         |
 
 ## Docker development
 

--- a/generators/client/templates/svelte/cypress/support/commands.js.ejs
+++ b/generators/client/templates/svelte/cypress/support/commands.js.ejs
@@ -24,7 +24,7 @@ Cypress.Commands.add('getByName', selector => {
 })
 <%_ if (authenticationType === 'session') { _%>
 Cypress.Commands.add('loginByApi', (username, password) => {
-	cy.session([username, password],
+	cy.session([username],
 		() => {
 			cy.request({ url: `api/authenticate` })
 				.then(res => {
@@ -40,8 +40,8 @@ Cypress.Commands.add('loginByApi', (username, password) => {
 							'X-XSRF-TOKEN': csrfCookie,
 						},
 						body: {
-							username: username,
-							password: password,
+							username,
+							password,
 							'remember-me': true,
 						},
 					})
@@ -63,14 +63,14 @@ Cypress.Commands.add('loginByApi', (username, password) => {
 })
 <%_ } else if (authenticationType === 'jwt') { _%>
 Cypress.Commands.add('loginByApi', (username, password) => {
-	cy.session([username, password],
+	cy.session([username],
 		() => {
 			cy.request({
 					method: 'POST',
 					url: `api/authenticate`,
 					body: {
-						username: username,
-						password: password,
+						username,
+						password,
 						'remember-me': false,
 					},
 				})
@@ -138,10 +138,23 @@ Cypress.Commands.add('delete', (url, lenient = true) => {
 		}
 	})
 })
+
+Cypress.Commands.add('getById', (url, status = 200) => {
+	cy.request({
+		method: 'GET',
+		url: url,
+		headers: {
+			Authorization: `Bearer ${localStorage.getItem('authToken') || sessionStorage.getItem('authToken')}`,
+		},
+	}).then(res => {
+		expect(res.status).to.eq(status)
+		return cy.wrap(res.body)
+	})
+})
 <%_ } else { _%>
 
 Cypress.Commands.add('loginByApi', (username, password) => {
-	cy.session([username, password],
+	cy.session([username],
 		() => {
 			cy.request({
 				url: '/oauth2/authorization/oidc',
@@ -188,8 +201,8 @@ Cypress.Commands.add('loginByApi', (username, password) => {
 									followRedirect: false,
 									form: true,
 									body: {
-										username: username,
-										password: password,
+										username,
+										password,
 									},
 								})
 							})
@@ -277,6 +290,24 @@ Cypress.Commands.add('delete', (url, lenient = true) => {
 			}
 		})
 })
+
+Cypress.Commands.add('getById', (url, status = 200) => {
+	cy.getCookie('XSRF-TOKEN')
+		.then(csrfCookie => {
+			return cy.request({
+				method: 'GET',
+				url: url,
+				headers: {
+					'X-XSRF-TOKEN': csrfCookie.value,
+				},
+			})
+		})
+		.then(res => {
+			expect(res.status).to.eq(status)
+			return cy.wrap(res.body)
+		})
+})
+
 <%_ } _%>
 
 Cypress.Commands.add('setFileInput', (fieldSelector, testFile, mimeType) => {

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -92,6 +92,10 @@ const svelteFiles = {
 					renameTo: generator =>
 						`cypress/integration/entities/${generator.entityFolderName}/${generator.entityInstance}-update.spec.js`,
 				},
+				{
+					file: 'cypress/support/entities/entity-util.js',
+					renameTo: generator => `cypress/support/entities/${generator.entityInstance}-util.js`,
+				},
 			],
 		},
 	],

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -3,6 +3,7 @@
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
 	const relationshipFields = relationships.filter(relationship => (
 		relationship.otherEntity.primaryKey
+			&& entityInstance !== relationship.otherEntity.entityInstance
 			&& (relationship.relationshipManyToOne
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -1,12 +1,43 @@
 <%_
 	const entityFakeData = generateFakeData('cypress');
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
+	const relationshipFields = relationships.filter(relationship => (
+		relationship.otherEntity.primaryKey
+			&& (relationship.relationshipManyToOne
+				|| (relationship.relationshipOneToOne && relationship.ownerSide)
+				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
+	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
 describe('<%= entityAngularName %> delete dialog page', () => {
 	let dynamicId
 
+	<%_ if (containsRelationshipField) { _%>
 	before(() => {
-		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+		cy.getById('api/users')
+			.its('0.id')
+			.as('userId')
+	<%_
+				} else {
+	_%>
+	<%_
+				}
+	_%>
+	<%_
+			}
+	_%>
+	})
+	<%_
+		}
+	_%>
+
+	before(function () {
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
 			Cypress.env('adminPassword')
@@ -43,6 +74,14 @@ _%>
 				<%= field.fieldName %>: '<%= fieldValue %>',
 				<%_ } _%>
 			<%_ } _%>
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+				user: { id: this.userId },
+	<%_
+				}
+			}
+	_%>
 <%_ if (containsBinaryField) { _%>
 			})
 <%_ } _%>

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -5,7 +5,7 @@ _%>
 describe('<%= entityAngularName %> delete dialog page', () => {
 	let dynamicId
 
-	beforeEach(() => {
+	before(() => {
 		cy.unregisterServiceWorkers()
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
@@ -48,34 +48,48 @@ _%>
 <%_ } _%>
 		}).then(res => {
 			dynamicId = res.id
-			cy.intercept('**/api/<%= entityApiUrl %>*').as('get<%= entityClassPlural %>')
-			cy.visit('/entities/<%= entityFolderName %>')
-			cy.wait('@get<%= entityClassPlural %>')
-			// eslint-disable-next-line
-			cy.wait(100)
-			cy.getBySel('<%= entityInstance %>Table')
-				.get('td:nth-child(1)').each(($el, index, $list) => {
-					const text = $el.text();
-					if(text.includes(dynamicId)) {
-						cy.getBySel('<%= entityInstance %>Table')
-							.get('td:nth-child(1)')
-							.eq(index)
-							.parent()
-							.trigger('mouseenter')
-							.within($tr => {
-								cy.root().get('td').children().getByName('delete<%= entityAngularName %>Btn').click()
-							})
-					}
-			})
 		})
 	})
 
-	afterEach(() => {
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+        cy.intercept('**/api/<%= entityApiUrl %>*').as('get<%= entityClassPlural %>')
+        cy.visit('/entities/<%= entityFolderName %>')
+        cy.wait('@get<%= entityClassPlural %>')
+        // eslint-disable-next-line
+        cy.wait(100)
+        cy.getBySel('<%= entityInstance %>Table')
+            .get('td:nth-child(1)').each(($el, index, $list) => {
+                const text = $el.text();
+                if(text.includes(dynamicId)) {
+                    cy.getBySel('<%= entityInstance %>Table')
+                        .get('td:nth-child(1)')
+                        .eq(index)
+                        .parent()
+                        .trigger('mouseenter')
+                        .within($tr => {
+                            cy.root().get('td').children().getByName('delete<%= entityAngularName %>Btn').click()
+                        })
+                }
+        })
+	})
+
+	after(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`, true)
 	<%_ if (authenticationType === 'oauth2') { _%>
 		cy.logoutByApi()
 	<%_ } _%>
 	})
+
+    <%_ if (authenticationType === 'oauth2') { _%>
+    afterEach(() => {
+        cy.logoutByApi()
+    })
+    <%_ } _%>
 
 	it('should display delete <%= entityAngularName %> dialog', () => {
 		cy.getBySel('svlModal').within(() => {

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-delete.spec.js.ejs
@@ -8,84 +8,43 @@
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
 	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
+import { prepare<%= entityAngularName %>PrerequisiteData, add<%= entityAngularName %> } from "../../../support/entities/<%= entityInstance %>-util.js";
+
 describe('<%= entityAngularName %> delete dialog page', () => {
 	let dynamicId
+<%_
+	if (containsRelationshipField || containsBinaryField ) {
+_%>
 
-	<%_ if (containsRelationshipField) { _%>
 	before(() => {
-		cy.loginByApi(
-			Cypress.env('adminUsername'),
-			Cypress.env('adminPassword')
-		)
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-		cy.getById('api/users')
-			.its('0.id')
-			.as('userId')
-	<%_
-				} else {
-	_%>
-	<%_
-				}
-	_%>
-	<%_
-			}
-	_%>
+		prepare<%= entityAngularName %>PrerequisiteData()
 	})
-	<%_
+<%_
 		}
-	_%>
+_%>
 
 	before(function () {
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
 			Cypress.env('adminPassword')
 		)
-<%_
+		add<%= entityAngularName %>(<%_
 	if (containsBinaryField) {
-_%>
-		cy.fixture('integration-test.png')
-			.then($blob => {
-				return <% } %>cy.save('api/<%= entityApiUrl %>', {
-			<%_
-				for (field of fields.filter(field => !field.id)) {
-					const fieldValue = !entityFakeData ? field.generateFakeData('cypress') : entityFakeData[field.fieldName];
-					if (fieldValue === undefined) {
-						warning(`Error generating a value for field ${field.fieldName}`);
-					}
-			_%>
-				<%_ if (field.fieldTypeBoolean) { _%>
-				<%= field.fieldName %>: true,
-				<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
-				<%= field.fieldName %>: $blob,
-				<%= field.fieldName %>ContentType: 'image/png',
-				<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } else if (field.fieldTypeLocalDate) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>' ,
-				<%_ } else if (field.fieldTypeTimed) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
-				<%_ } else if (field.fieldTypeDuration) { _%>
-				<%= field.fieldName %>: 'PT0.000052484S',
-				<%_ } else if (field.fieldTypeNumeric) { _%>
-				<%= field.fieldName %>: <%= fieldValue %>,
-				<%_ } else { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } _%>
-			<%_ } _%>
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-				user: { id: this.userId },
-	<%_
-				}
+_%>this.binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>this.userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%>this.<%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			}
-	_%>
-<%_ if (containsBinaryField) { _%>
-			})
-<%_ } _%>
-		}).then(res => {
+			fieldIndex++;
+		}
+_%>)
+		.then(res => {
 			dynamicId = res.id
 		})
 	})
@@ -117,11 +76,20 @@ _%>
         })
 	})
 
-	after(() => {
+	after(function () {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`, true)
 	<%_ if (authenticationType === 'oauth2') { _%>
 		cy.logoutByApi()
 	<%_ } _%>
+	<%_
+			for (const relationship of relationshipFields) {
+				if (!relationship.otherEntityUser) {
+	_%>
+		cy.delete(`api/<%= relationship.otherEntity.entityApiUrl %>/${this.<%= relationship.relationshipName %>Id}`, true)
+	<%_
+				}
+			}
+	_%>
 	})
 
     <%_ if (authenticationType === 'oauth2') { _%>

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -1,14 +1,45 @@
 <%_
 	const entityFakeData = generateFakeData('cypress');
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
+	const relationshipFields = relationships.filter(relationship => (
+		relationship.otherEntity.primaryKey
+			&& (relationship.relationshipManyToOne
+				|| (relationship.relationshipOneToOne && relationship.ownerSide)
+				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
+	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
 describe('<%= entityAngularName %> list page', () => {
 	let dynamicId
 <%_ if (!paginationNo || searchEngine) { _%>
 	let dynamicId2
 <%_ } _%>
+	<%_ if (containsRelationshipField) { _%>
 	before(() => {
-		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+		cy.getById('api/users')
+			.its('0.id')
+			.as('userId')
+	<%_
+				} else {
+	_%>
+	<%_
+				}
+	_%>
+	<%_
+			}
+	_%>
+	})
+	<%_
+		}
+	_%>
+
+	before(function() {
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
 			Cypress.env('adminPassword')
@@ -45,6 +76,14 @@ describe('<%= entityAngularName %> list page', () => {
 				<%= field.fieldName %>: '<%= fieldValue %>',
 				<%_ } _%>
 			<%_ } _%>
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+				user: { id: this.userId },
+	<%_
+				}
+			}
+	_%>
 <%_ if (containsBinaryField) { _%>
 			})
 <%_ } _%>
@@ -83,6 +122,14 @@ describe('<%= entityAngularName %> list page', () => {
 				<%= field.fieldName %>: '<%= fieldValue %>',
 				<%_ } _%>
 			<%_ } _%>
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+				user: { id: this.userId },
+	<%_
+				}
+			}
+	_%>
 <%_ if (containsBinaryField) { _%>
 			})
 <%_ } _%>

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -3,6 +3,7 @@
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
 	const relationshipFields = relationships.filter(relationship => (
 		relationship.otherEntity.primaryKey
+			&& entityInstance !== relationship.otherEntity.entityInstance
 			&& (relationship.relationshipManyToOne
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -7,7 +7,7 @@ describe('<%= entityAngularName %> list page', () => {
 <%_ if (!paginationNo || searchEngine) { _%>
 	let dynamicId2
 <%_ } _%>
-	beforeEach(() => {
+	before(() => {
 		cy.unregisterServiceWorkers()
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
@@ -88,15 +88,23 @@ describe('<%= entityAngularName %> list page', () => {
 <%_ } _%>
 		}).then(res => {
 			dynamicId = res.id
-			cy.intercept('**/api/<%= entityApiUrl %>*').as('get<%= entityClassPlural %>')
-			cy.visit('/entities/<%= entityFolderName %>')
-			cy.wait('@get<%= entityClassPlural %>')
-			// eslint-disable-next-line
-			cy.wait(100)
 		})
 	})
 
-	afterEach(() => {
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+        cy.intercept('**/api/<%= entityApiUrl %>*').as('get<%= entityClassPlural %>')
+        cy.visit('/entities/<%= entityFolderName %>')
+        cy.wait('@get<%= entityClassPlural %>')
+        // eslint-disable-next-line
+        cy.wait(100)
+	})
+
+	after(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
 	<%_ if (!paginationNo || searchEngine) { _%>
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId2}`)
@@ -105,6 +113,12 @@ describe('<%= entityAngularName %> list page', () => {
 		cy.logoutByApi()
 	<%_ } _%>
 	})
+
+    <%_ if (authenticationType === 'oauth2') { _%>
+    afterEach(() => {
+        cy.logoutByApi()
+    })
+    <%_ } _%>
 
 	it('should greets with <%= entityAngularName %> page title', () => {
 		cy.getBySel('<%= entityInstance %>Title')

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -8,6 +8,7 @@
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
 	const containsRelationshipField = relationshipFields && relationshipFields.length;
+	const oneToOneRelationship = relationshipFields.filter(relationship => relationship.relationshipOneToOne);
 _%>
 import { prepare<%= entityAngularName %>PrerequisiteData, add<%= entityAngularName %><% if (!paginationNo || searchEngine) { %>, add<%= entityAngularName %>2<% } %> } from "../../../support/entities/<%= entityInstance %>-util.js";
 
@@ -20,7 +21,7 @@ describe('<%= entityAngularName %> list page', () => {
 	if (containsRelationshipField || containsBinaryField ) {
 _%>
 	before(() => {
-		prepare<%= entityAngularName %>PrerequisiteData()
+		prepare<%= entityAngularName %>PrerequisiteData(<%= !!(!paginationNo || searchEngine) %>)
 	})
 <%_
 		}
@@ -44,7 +45,7 @@ _%>,<%_} _%><%_
 			if (relationship.otherEntityUser) {
 _%>this.userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			} else {
-_%>this.<%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+_%>this.<%= relationship.relationshipName %>Id<%_ if (relationship.relationshipOneToOne) { _%>2<%_ } _%><%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			}
 			fieldIndex++;
 		}
@@ -107,7 +108,12 @@ _%>
 				if (!relationship.otherEntityUser) {
 	_%>
 		cy.delete(`api/<%= relationship.otherEntity.entityApiUrl %>/${this.<%= relationship.relationshipName %>Id}`, true)
-	<%_
+<%_
+					if (relationship.relationshipOneToOne && (!paginationNo || searchEngine)) {
+_%>
+		cy.delete(`api/<%= relationship.otherEntity.entityApiUrl %>/${this.<%= relationship.relationshipName %>Id2}`, true)
+<%_
+					}
 				}
 			}
 	_%>

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-list.spec.js.ejs
@@ -8,36 +8,22 @@
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
 	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
+import { prepare<%= entityAngularName %>PrerequisiteData, add<%= entityAngularName %><% if (!paginationNo || searchEngine) { %>, add<%= entityAngularName %>2<% } %> } from "../../../support/entities/<%= entityInstance %>-util.js";
+
 describe('<%= entityAngularName %> list page', () => {
 	let dynamicId
 <%_ if (!paginationNo || searchEngine) { _%>
 	let dynamicId2
 <%_ } _%>
-	<%_ if (containsRelationshipField) { _%>
+<%_
+	if (containsRelationshipField || containsBinaryField ) {
+_%>
 	before(() => {
-		cy.loginByApi(
-			Cypress.env('adminUsername'),
-			Cypress.env('adminPassword')
-		)
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-		cy.getById('api/users')
-			.its('0.id')
-			.as('userId')
-	<%_
-				} else {
-	_%>
-	<%_
-				}
-	_%>
-	<%_
-			}
-	_%>
+		prepare<%= entityAngularName %>PrerequisiteData()
 	})
-	<%_
+<%_
 		}
-	_%>
+_%>
 
 	before(function() {
 		cy.loginByApi(
@@ -46,94 +32,44 @@ describe('<%= entityAngularName %> list page', () => {
 		)
 	<%_ if (!paginationNo || searchEngine) { _%>
 		// create another <%= entityAngularName %> to test sort implementation
-<%_ if (containsBinaryField) { _%>
-		cy.fixture('integration-test.png')
-			.then($blob => {
-				return <% } %>cy.save('api/<%= entityApiUrl %>', {
-			<%_
-				for (field of fields.filter(field => !field.id)) {
-					const fieldValue = !entityFakeData ? field.generateFakeData('cypress') : entityFakeData[field.fieldName];
-					if (fieldValue === undefined) {
-						warning(`Error generating a value for field ${field.fieldName}`);
-					}
-			_%>
-				<%_ if (field.fieldTypeBoolean) { _%>
-				<%= field.fieldName %>: true,
-				<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
-				<%= field.fieldName %>: $blob,
-				<%= field.fieldName %>ContentType: 'image/png',
-				<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } else if (field.fieldTypeLocalDate) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>' ,
-				<%_ } else if (field.fieldTypeTimed) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
-				<%_ } else if (field.fieldTypeDuration) { _%>
-				<%= field.fieldName %>: 'PT0.000052484S',
-				<%_ } else if (field.fieldTypeNumeric) { _%>
-				<%= field.fieldName %>: <%= fieldValue %>,
-				<%_ } else { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } _%>
-			<%_ } _%>
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-				user: { id: this.userId },
-	<%_
-				}
+		add<%= entityAngularName %>2(<%_
+	if (containsBinaryField) {
+_%>this.binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>this.userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%>this.<%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			}
-	_%>
-<%_ if (containsBinaryField) { _%>
-			})
-<%_ } _%>
-		}).then(res => {
+			fieldIndex++;
+		}
+_%>)
+		.then(res => {
 			dynamicId2 = res.id
 		})
 	<%_ } _%>
 
-<%_ if (containsBinaryField) { _%>
-		cy.fixture('integration-test.png')
-			.then($blob => {
-				return <% } %>cy.save('api/<%= entityApiUrl %>', {
-			<%_
-				for (field of fields.filter(field => !field.id)) {
-					const fieldValue = !entityFakeData ? field.generateFakeData('cypress') : entityFakeData[field.fieldName];
-					if (fieldValue === undefined) {
-						warning(`Error generating a value for field ${field.fieldName}`);
-					}
-			_%>
-				<%_ if (field.fieldTypeBoolean) { _%>
-				<%= field.fieldName %>: true,
-				<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
-				<%= field.fieldName %>: $blob,
-				<%= field.fieldName %>ContentType: 'image/png',
-				<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } else if (field.fieldTypeLocalDate) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>' ,
-				<%_ } else if (field.fieldTypeTimed) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
-				<%_ } else if (field.fieldTypeDuration) { _%>
-				<%= field.fieldName %>: 'PT0.000052484S',
-				<%_ } else if (field.fieldTypeNumeric) { _%>
-				<%= field.fieldName %>: <%= fieldValue %>,
-				<%_ } else { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } _%>
-			<%_ } _%>
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-				user: { id: this.userId },
-	<%_
-				}
+		add<%= entityAngularName %>(<%_
+	if (containsBinaryField) {
+_%>this.binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>this.userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%>this.<%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			}
-	_%>
-<%_ if (containsBinaryField) { _%>
-			})
-<%_ } _%>
-		}).then(res => {
+			fieldIndex++;
+		}
+_%>)
+		.then(res => {
 			dynamicId = res.id
 		})
 	})
@@ -151,14 +87,29 @@ describe('<%= entityAngularName %> list page', () => {
         cy.wait(100)
 	})
 
-	after(() => {
+	after(function() {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
-	<%_ if (!paginationNo || searchEngine) { _%>
+<%_
+	if (!paginationNo || searchEngine) {
+_%>
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId2}`)
-	<%_ }
-	if (authenticationType === 'oauth2') { _%>
+<%_
+	}
+	if (authenticationType === 'oauth2') {
+_%>
 		cy.logoutByApi()
-	<%_ } _%>
+<%_
+	}
+_%>
+	<%_
+			for (const relationship of relationshipFields) {
+				if (!relationship.otherEntityUser) {
+	_%>
+		cy.delete(`api/<%= relationship.otherEntity.entityApiUrl %>/${this.<%= relationship.relationshipName %>Id}`, true)
+	<%_
+				}
+			}
+	_%>
 	})
 
     <%_ if (authenticationType === 'oauth2') { _%>

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
@@ -224,7 +224,14 @@ _%>
 			.should('be.visible')
 			.should('contain', '<%= entityClassPluralHumanized %>')
 	})
-
+<%_
+	if (searchEngine) {
+_%>
+/*
+// Observed java.lang.StackOverflowError while updating an entity with elasticsearch integration
+<%_
+	}
+_%>
 	it('should update <%= entityInstance %> details', () => {
 		cy.getBySel('add<%= entityAngularName %>Form')
 	<%_
@@ -287,4 +294,11 @@ _%>
 			.should('be.visible')
 			.should('contain', '<%= entityClassPluralHumanized %>')
 	})
+<%_
+	if (searchEngine) {
+_%>
+*/
+<%_
+	}
+_%>
 })

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
@@ -18,12 +18,43 @@
 		}
 		return maxLengthText;
 	}
+	const relationshipFields = relationships.filter(relationship => (
+		relationship.otherEntity.primaryKey
+			&& (relationship.relationshipManyToOne
+				|| (relationship.relationshipOneToOne && relationship.ownerSide)
+				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
+	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
 describe('Update <%= entityInstance %> page', () => {
 	let dynamicId
 
+	<%_ if (containsRelationshipField) { _%>
 	before(() => {
-		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+		cy.getById('api/users')
+			.its('0.id')
+			.as('userId')
+	<%_
+				} else {
+	_%>
+	<%_
+				}
+	_%>
+	<%_
+			}
+	_%>
+	})
+	<%_
+		}
+	_%>
+
+	before(function() {
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
 			Cypress.env('adminPassword')
@@ -59,6 +90,14 @@ describe('Update <%= entityInstance %> page', () => {
 				<%= field.fieldName %>: '<%= fieldValue %>',
 				<%_ } _%>
 			<%_ } _%>
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+				user: { id: this.userId },
+	<%_
+				}
+			}
+	_%>
 <%_ if (containsBinaryField) { _%>
 			})
 <%_ } _%>

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
@@ -22,7 +22,7 @@ _%>
 describe('Update <%= entityInstance %> page', () => {
 	let dynamicId
 
-	beforeEach(() => {
+	before(() => {
 		cy.unregisterServiceWorkers()
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
@@ -64,16 +64,30 @@ describe('Update <%= entityInstance %> page', () => {
 <%_ } _%>
 		}).then(res => {
 			dynamicId = res.id
-			cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/edit`)
 		})
 	})
 
-	afterEach(() => {
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+        cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/edit`)
+	})
+
+	after(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
 	<%_ if (authenticationType === 'oauth2') { _%>
 		cy.logoutByApi()
 	<%_ } _%>
 	})
+
+    <%_ if (authenticationType === 'oauth2') { _%>
+    afterEach(() => {
+        cy.logoutByApi()
+    })
+    <%_ } _%>
 
 	it('should greets with update <%= entityInstance %> title', () => {
 		cy.getBySel('<%= entityInstance %>Title')

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
@@ -20,6 +20,7 @@
 	}
 	const relationshipFields = relationships.filter(relationship => (
 		relationship.otherEntity.primaryKey
+			&& entityInstance !== relationship.otherEntity.entityInstance
 			&& (relationship.relationshipManyToOne
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
@@ -146,6 +147,7 @@ _%>
 
 		cy.getBySel('add<%= entityAngularName %>Form')
 			.getByName('<%= field.fieldName %>')
+			.clear()
 			.type(
 				'<%= getMinLengthText(field.fieldValidateRulesMinlength) %>'
 			)
@@ -159,6 +161,7 @@ _%>
 
 		cy.getBySel('add<%= entityAngularName %>Form')
 			.getByName('<%= field.fieldName %>')
+			.clear()
 			.type(
 				'<%= getMaxLengthText(field.fieldValidateRulesMaxlength) %>'
 			)
@@ -243,8 +246,7 @@ _%>
 			cy.root().get("input[type='checkbox']").eq(0).check()
 			cy.root().get("input[type='checkbox']").eq(1).check()
 		})
-		.getBySel('<%= field.fieldName %>-bg')
-		.click()
+		.type('{esc}')
             <%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
         .getByName('<%= field.fieldName %>ClearBtn')
         .click()

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-update.spec.js.ejs
@@ -25,34 +25,20 @@
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
 	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
+import { prepare<%= entityAngularName %>PrerequisiteData, add<%= entityAngularName %> } from "../../../support/entities/<%= entityInstance %>-util.js";
+
 describe('Update <%= entityInstance %> page', () => {
 	let dynamicId
+<%_
+	if (containsRelationshipField || containsBinaryField ) {
+_%>
 
-	<%_ if (containsRelationshipField) { _%>
 	before(() => {
-		cy.loginByApi(
-			Cypress.env('adminUsername'),
-			Cypress.env('adminPassword')
-		)
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-		cy.getById('api/users')
-			.its('0.id')
-			.as('userId')
-	<%_
-				} else {
-	_%>
-	<%_
-				}
-	_%>
-	<%_
-			}
-	_%>
+		prepare<%= entityAngularName %>PrerequisiteData()
 	})
-	<%_
+<%_
 		}
-	_%>
+_%>
 
 	before(function() {
 		cy.loginByApi(
@@ -60,48 +46,23 @@ describe('Update <%= entityInstance %> page', () => {
 			Cypress.env('adminPassword')
 		)
 
-<%_ if (containsBinaryField) { _%>
-		cy.fixture('integration-test.png')
-			.then($blob => {
-				return <% } %>cy.save('api/<%= entityApiUrl %>', {
-			<%_
-				for (field of fields.filter(field => !field.id)) {
-					const fieldValue = !entityFakeData ? field.generateFakeData('cypress') : entityFakeData[field.fieldName];
-					if (fieldValue === undefined) {
-						warning(`Error generating a value for field ${field.fieldName}`);
-					}
-			_%>
-				<%_ if (field.fieldTypeBoolean) { _%>
-				<%= field.fieldName %>: <%= fieldValue %>,
-				<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
-				<%= field.fieldName %>: $blob,
-				<%= field.fieldName %>ContentType: 'image/png',
-				<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } else if (field.fieldTypeLocalDate) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>' ,
-				<%_ } else if (field.fieldTypeTimed) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
-				<%_ } else if (field.fieldTypeDuration) { _%>
-				<%= field.fieldName %>: 'PT0.000052484S',
-				<%_ } else if (field.fieldTypeNumeric) { _%>
-				<%= field.fieldName %>: <%= fieldValue %>,
-				<%_ } else { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } _%>
-			<%_ } _%>
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-				user: { id: this.userId },
-	<%_
-				}
+		add<%= entityAngularName %>(<%_
+	if (containsBinaryField) {
+_%>this.binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>this.userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%>this.<%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			}
-	_%>
-<%_ if (containsBinaryField) { _%>
-			})
-<%_ } _%>
-		}).then(res => {
+			fieldIndex++;
+		}
+_%>)
+		.then(res => {
 			dynamicId = res.id
 		})
 	})
@@ -115,11 +76,20 @@ describe('Update <%= entityInstance %> page', () => {
         cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/edit`)
 	})
 
-	after(() => {
+	after(function () {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
 	<%_ if (authenticationType === 'oauth2') { _%>
 		cy.logoutByApi()
 	<%_ } _%>
+	<%_
+			for (const relationship of relationshipFields) {
+				if (!relationship.otherEntityUser) {
+	_%>
+		cy.delete(`api/<%= relationship.otherEntity.entityApiUrl %>/${this.<%= relationship.relationshipName %>Id}`, true)
+	<%_
+				}
+			}
+	_%>
 	})
 
     <%_ if (authenticationType === 'oauth2') { _%>
@@ -138,26 +108,19 @@ describe('Update <%= entityInstance %> page', () => {
 		cy.getBySel('add<%= entityAngularName %>Form')
 		<%_
 			for (field of fields.filter(field => !field.id)) {
-				const fieldValue = !entityFakeData ? field.generateFakeData('cypress') : entityFakeData[field.fieldName];
 		_%>
-			<%_ if (!field.fieldTypeTimed && !field.fieldTypeDuration) { _%>
+			<%_ if (!field.fieldTypeTimed && !field.fieldTypeDuration && !field.fieldTypeBoolean) { _%>
     		    <%_ if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
 			.getBySel('<%= field.fieldName %>View')
 			.should('contain', 'image/png')
                 <%_ } else { _%>
 			.getByName('<%= field.fieldName %>')
-				    <%_ if (field.fieldTypeBoolean) { _%>
-					    <%_ if (fieldValue === false) { _%>
-			.should('not.be.checked')
-					    <%_ } else { _%>
-			.should('be.checked')
-					    <%_ } _%>
-				    <%_ } else { _%>
-			.should('have.value', '<%= fieldValue %>')
-                    <%_ } _%>
-                <%_ } _%>
+			.invoke('val')
+			.should('not.be.empty')
 			<%_ } _%>
-		<%_ } _%>
+		<%_ }
+		}
+		_%>
 		cy.getBySel('add<%= entityAngularName %>Form')
 			.contains('Update <%= entityClassHumanized %>')
 			.should('not.be.disabled')
@@ -291,6 +254,22 @@ _%>
 			<%_ } _%>
 		<%_ } _%>
 	<%_ } _%>
+	<%_
+		for (const relationship of relationshipFields) {
+			let relationshipFieldKey
+			if (relationship.relationshipManyToMany) {
+				relationshipFieldKey = relationship.relationshipNamePlural;
+			} else {
+				relationshipFieldKey = relationship.relationshipName;
+			}
+	_%>
+		.getByName('<%= relationshipFieldKey %>')
+		.click()
+		.getBySel('<%= relationshipFieldKey %>-options')
+		.type('{esc}')
+	<%_
+		}
+	_%>
 		cy.getBySel('add<%= entityAngularName %>Form')
 			.contains('Update <%= entityClassHumanized %>')
 			.should('not.be.disabled')

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -5,7 +5,7 @@ _%>
 describe('<%= entityAngularName %> view details page', () => {
 	let dynamicId
 
-	beforeEach(() => {
+	before(() => {
 		cy.unregisterServiceWorkers()
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
@@ -47,16 +47,30 @@ describe('<%= entityAngularName %> view details page', () => {
 <%_ } _%>
 		}).then(res => {
 			dynamicId = res.id
-			cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/view`)
 		})
 	})
 
-	afterEach(() => {
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+        cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/view`)
+	})
+
+	after(() => {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
 	<%_ if (authenticationType === 'oauth2') { _%>
 		cy.logoutByApi()
 	<%_ } _%>
 	})
+
+    <%_ if (authenticationType === 'oauth2') { _%>
+    afterEach(() => {
+        cy.logoutByApi()
+    })
+    <%_ } _%>
 
 	it('should display <%= entityAngularName %> details', () => {
 		cy.getBySel('<%= entityInstance %>Title')

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -3,6 +3,12 @@
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
 	const relationshipFields = relationships.filter(relationship => (
 		relationship.otherEntity.primaryKey
+			&& entityInstance !== relationship.otherEntity.entityInstance
+			&& (relationship.relationshipManyToOne
+				|| (relationship.relationshipOneToOne && relationship.ownerSide)
+				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
+	const relationshipFieldsWithSelfReferential = relationships.filter(relationship => (
+		relationship.otherEntity.primaryKey
 			&& (relationship.relationshipManyToOne
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
@@ -90,7 +96,7 @@ _%>)
 		cy.get('div.table').within(() => {
 			cy.root()
 				.get('.table-cell')
-				.should('have.length', <%= (fields.length - 1) * 2 + (relationshipFields.length * 2) %>)
+				.should('have.length', <%= (fields.length - 1) * 2 + (relationshipFieldsWithSelfReferential.length * 2) %>)
 		})
 	})
 

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -1,12 +1,43 @@
 <%_
 	const entityFakeData = generateFakeData('cypress');
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
+	const relationshipFields = relationships.filter(relationship => (
+		relationship.otherEntity.primaryKey
+			&& (relationship.relationshipManyToOne
+				|| (relationship.relationshipOneToOne && relationship.ownerSide)
+				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
+	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
 describe('<%= entityAngularName %> view details page', () => {
 	let dynamicId
 
+	<%_ if (containsRelationshipField) { _%>
 	before(() => {
-		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('adminUsername'),
+			Cypress.env('adminPassword')
+		)
+	<%_		for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+		cy.getById('api/users')
+			.its('0.id')
+			.as('userId')
+	<%_
+				} else {
+	_%>
+	<%_
+				}
+	_%>
+	<%_
+			}
+	_%>
+	})
+	<%_
+		}
+	_%>
+
+	before(function() {
 		cy.loginByApi(
 			Cypress.env('adminUsername'),
 			Cypress.env('adminPassword')
@@ -42,6 +73,15 @@ describe('<%= entityAngularName %> view details page', () => {
 				<%= field.fieldName %>: '<%= fieldValue %>',
 				<%_ } _%>
 			<%_ } _%>
+	<%_
+			for (const relationship of relationshipFields) {
+				if (relationship.otherEntityUser) {
+	_%>
+				user: { id: this.userId },
+	<%_
+				}
+			}
+	_%>
 <%_ if (containsBinaryField) { _%>
 			})
 <%_ } _%>
@@ -80,7 +120,7 @@ describe('<%= entityAngularName %> view details page', () => {
 		cy.get('div.table').within(() => {
 			cy.root()
 				.get('.table-cell')
-				.should('have.length', <%= (fields.length - 1) * 2 %>)
+				.should('have.length', <%= (fields.length - 1) * 2 + (relationshipFields.length * 2) %>)
 		})
 	})
 

--- a/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/integration/entities/entity/entity-view.spec.js.ejs
@@ -8,34 +8,21 @@
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
 	const containsRelationshipField = relationshipFields && relationshipFields.length;
 _%>
+import { prepare<%= entityAngularName %>PrerequisiteData, add<%= entityAngularName %> } from "../../../support/entities/<%= entityInstance %>-util.js";
+
 describe('<%= entityAngularName %> view details page', () => {
 	let dynamicId
 
-	<%_ if (containsRelationshipField) { _%>
+<%_
+	if (containsRelationshipField || containsBinaryField ) {
+_%>
+
 	before(() => {
-		cy.loginByApi(
-			Cypress.env('adminUsername'),
-			Cypress.env('adminPassword')
-		)
-	<%_		for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-		cy.getById('api/users')
-			.its('0.id')
-			.as('userId')
-	<%_
-				} else {
-	_%>
-	<%_
-				}
-	_%>
-	<%_
-			}
-	_%>
+		prepare<%= entityAngularName %>PrerequisiteData()
 	})
-	<%_
+<%_
 		}
-	_%>
+_%>
 
 	before(function() {
 		cy.loginByApi(
@@ -43,49 +30,23 @@ describe('<%= entityAngularName %> view details page', () => {
 			Cypress.env('adminPassword')
 		)
 
-<%_ if (containsBinaryField) { _%>
-		cy.fixture('integration-test.png')
-			.then($blob => {
-				return <% } %>cy.save('api/<%= entityApiUrl %>', {
-			<%_
-				for (field of fields.filter(field => !field.id)) {
-					const fieldValue = !entityFakeData ? field.generateFakeData('cypress') : entityFakeData[field.fieldName];
-					if (fieldValue === undefined) {
-						warning(`Error generating a value for field ${field.fieldName}`);
-					}
-			_%>
-				<%_ if (field.fieldTypeBoolean) { _%>
-				<%= field.fieldName %>: true,
-				<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
-				<%= field.fieldName %>: $blob,
-				<%= field.fieldName %>ContentType: 'image/png',
-				<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } else if (field.fieldTypeLocalDate) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>' ,
-				<%_ } else if (field.fieldTypeTimed) { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
-				<%_ } else if (field.fieldTypeDuration) { _%>
-				<%= field.fieldName %>: 'PT0.000052484S',
-				<%_ } else if (field.fieldTypeNumeric) { _%>
-				<%= field.fieldName %>: <%= fieldValue %>,
-				<%_ } else { _%>
-				<%= field.fieldName %>: '<%= fieldValue %>',
-				<%_ } _%>
-			<%_ } _%>
-	<%_
-			for (const relationship of relationshipFields) {
-				if (relationship.otherEntityUser) {
-	_%>
-				user: { id: this.userId },
-	<%_
-				}
+		add<%= entityAngularName %>(<%_
+	if (containsBinaryField) {
+_%>this.binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>this.userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%>this.<%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
 			}
-	_%>
-<%_ if (containsBinaryField) { _%>
-			})
-<%_ } _%>
-		}).then(res => {
+			fieldIndex++;
+		}
+_%>)
+		.then(res => {
 			dynamicId = res.id
 		})
 	})
@@ -99,11 +60,20 @@ describe('<%= entityAngularName %> view details page', () => {
         cy.visit(`/entities/<%= entityFolderName %>/${dynamicId}/view`)
 	})
 
-	after(() => {
+	after(function () {
 		cy.delete(`api/<%= entityApiUrl %>/${dynamicId}`)
 	<%_ if (authenticationType === 'oauth2') { _%>
 		cy.logoutByApi()
 	<%_ } _%>
+	<%_
+			for (const relationship of relationshipFields) {
+				if (!relationship.otherEntityUser) {
+	_%>
+		cy.delete(`api/<%= relationship.otherEntity.entityApiUrl %>/${this.<%= relationship.relationshipName %>Id}`, true)
+	<%_
+				}
+			}
+	_%>
 	})
 
     <%_ if (authenticationType === 'oauth2') { _%>

--- a/generators/entity-client/templates/svelte/cypress/support/entities/entity-util.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/support/entities/entity-util.js.ejs
@@ -3,6 +3,7 @@
 	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
 	const relationshipFields = relationships.filter(relationship => (
 		relationship.otherEntity.primaryKey
+			&& entityInstance !== relationship.otherEntity.entityInstance
 			&& (relationship.relationshipManyToOne
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))

--- a/generators/entity-client/templates/svelte/cypress/support/entities/entity-util.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/support/entities/entity-util.js.ejs
@@ -1,0 +1,202 @@
+<%_
+	const entityFakeData = generateFakeData('cypress');
+	const containsBinaryField = fields.find(field => (field.fieldTypeBinary && !field.blobContentTypeText));
+	const relationshipFields = relationships.filter(relationship => (
+		relationship.otherEntity.primaryKey
+			&& (relationship.relationshipManyToOne
+				|| (relationship.relationshipOneToOne && relationship.ownerSide)
+				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
+	const containsRelationshipField = relationshipFields && relationshipFields.length;
+_%>
+
+export function prepare<%= entityAngularName %>PrerequisiteData() {
+<%_ if (containsBinaryField) { _%>
+	cy.fixture('integration-test.png').as('binaryData')
+<%_ } _%>
+<%_ if (containsRelationshipField) { _%>
+	cy.loginByApi(
+		Cypress.env('adminUsername'),
+		Cypress.env('adminPassword')
+	)
+<%_ } _%>
+<%_
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>
+	cy.getById('api/users')
+		.its('0.id')
+		.as('userId')
+	<%_
+			} else {
+	_%>
+
+	cy.save('api/<%= relationship.otherEntity.entityApiUrl %>', {
+	<%_
+		for (const relationshipField of relationship.otherEntity.fields.filter(field => !field.id)) {
+			const fieldValue = relationshipField.generateFakeData('cypress');
+			if (fieldValue === undefined) {
+				warning(`Error generating a value for field ${relationshipField.fieldName}`);
+			}
+	_%>
+		<%_ if (relationshipField.fieldTypeBoolean) { _%>
+		<%= relationshipField.fieldName %>: true,
+		<%_ } else if (relationshipField.fieldTypeBinary && !relationshipField.blobContentTypeText) { _%>
+		// <%= relationshipField.fieldName %>: this.binaryData,
+		<%= relationshipField.fieldName %>ContentType: 'image/png',
+		<%_ } else if (relationshipField.fieldTypeString || relationshipField.fieldTypeUUID) { _%>
+		<%= relationshipField.fieldName %>: '<%= fieldValue %>',
+		<%_ } else if (relationshipField.fieldTypeLocalDate) { _%>
+		<%= relationshipField.fieldName %>: '<%= fieldValue %>' ,
+		<%_ } else if (relationshipField.fieldTypeTimed) { _%>
+		<%= relationshipField.fieldName %>: '<%= fieldValue %>:00.000Z' ,
+		<%_ } else if (relationshipField.fieldTypeDuration) { _%>
+		<%= relationshipField.fieldName %>: 'PT0.000052484S',
+		<%_ } else if (relationshipField.fieldTypeNumeric) { _%>
+		<%= relationshipField.fieldName %>: <%= fieldValue %>,
+		<%_ } else { _%>
+		<%= relationshipField.fieldName %>: '<%= fieldValue %>',
+		<%_ } _%>
+	<%_
+		}
+	_%>
+	}).its('id').as('<%= relationship.relationshipName %>Id')
+	<%_
+			}
+	_%>
+	<%_
+		}
+	_%>
+}
+
+export function add<%= entityAngularName %>(<%_
+	if (containsBinaryField) {
+_%>binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%><%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			}
+			fieldIndex++;
+		}
+_%>) {
+	return cy.save('api/<%= entityApiUrl %>', {
+<%_
+	for (field of fields.filter(field => !field.id)) {
+		const fieldValue = field.generateFakeData('cypress');
+		if (fieldValue === undefined) {
+			warning(`Error generating a value for field ${field.fieldName}`);
+		}
+_%>
+		<%_ if (field.fieldTypeBoolean) { _%>
+		<%= field.fieldName %>: true,
+		<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
+		<%= field.fieldName %>: binaryData,
+		<%= field.fieldName %>ContentType: 'image/png',
+		<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>',
+		<%_ } else if (field.fieldTypeLocalDate) { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>' ,
+		<%_ } else if (field.fieldTypeTimed) { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
+		<%_ } else if (field.fieldTypeDuration) { _%>
+		<%= field.fieldName %>: 'PT0.000052484S',
+		<%_ } else if (field.fieldTypeNumeric) { _%>
+		<%= field.fieldName %>: <%= fieldValue %>,
+		<%_ } else { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>',
+		<%_ } _%>
+	<%_ } _%>
+<%_		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>
+		user: { id: userId },
+<%_
+			} else {
+				if (relationship.relationshipManyToMany) {
+_%>
+		<%= relationship.relationshipNamePlural %>: [{ id: <%= relationship.relationshipName %>Id }],
+	<%_
+				} else {
+	_%>
+		<%= relationship.relationshipName %>: { id: <%= relationship.relationshipName %>Id },
+	<%_
+				}
+			}
+		}
+_%>
+	})
+}
+<%_
+	if (!paginationNo || searchEngine) {
+_%>
+export function add<%= entityAngularName %>2(<%_
+	if (containsBinaryField) {
+_%>binaryData<%_} _%><%_
+	if (containsBinaryField && containsRelationshipField) {
+_%>,<%_} _%><%_
+		let fieldIndex = 0;
+		const fieldLength = relationshipFields.length;
+		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>userId<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			} else {
+_%><%= relationship.relationshipName %>Id<%_ if (fieldIndex !== (fieldLength - 1)) { _%>,<%_ } _%><%_
+			}
+			fieldIndex++;
+		}
+_%>) {
+	return cy.save('api/<%= entityApiUrl %>', {
+<%_
+	for (field of fields.filter(field => !field.id)) {
+		const fieldValue = field.generateFakeData('cypress');
+		if (fieldValue === undefined) {
+			warning(`Error generating a value for field ${field.fieldName}`);
+		}
+_%>
+		<%_ if (field.fieldTypeBoolean) { _%>
+		<%= field.fieldName %>: true,
+		<%_ } else if (field.fieldTypeBinary && !field.blobContentTypeText) { _%>
+		<%= field.fieldName %>: binaryData,
+		<%= field.fieldName %>ContentType: 'image/png',
+		<%_ } else if (field.fieldTypeString || field.fieldTypeUUID) { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>',
+		<%_ } else if (field.fieldTypeLocalDate) { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>' ,
+		<%_ } else if (field.fieldTypeTimed) { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>:00.000Z' ,
+		<%_ } else if (field.fieldTypeDuration) { _%>
+		<%= field.fieldName %>: 'PT0.000052484S',
+		<%_ } else if (field.fieldTypeNumeric) { _%>
+		<%= field.fieldName %>: <%= fieldValue %>,
+		<%_ } else { _%>
+		<%= field.fieldName %>: '<%= fieldValue %>',
+		<%_ } _%>
+	<%_ } _%>
+<%_		for (const relationship of relationshipFields) {
+			if (relationship.otherEntityUser) {
+_%>
+		user: { id: userId },
+<%_
+			} else {
+				if (relationship.relationshipManyToMany) {
+_%>
+		<%= relationship.relationshipNamePlural %>: [{ id: <%= relationship.relationshipName %>Id }],
+	<%_
+				} else {
+	_%>
+		<%= relationship.relationshipName %>: { id: <%= relationship.relationshipName %>Id },
+	<%_
+				}
+			}
+		}
+_%>
+	})
+}
+<%_
+	}
+_%>

--- a/generators/entity-client/templates/svelte/cypress/support/entities/entity-util.js.ejs
+++ b/generators/entity-client/templates/svelte/cypress/support/entities/entity-util.js.ejs
@@ -8,9 +8,11 @@
 				|| (relationship.relationshipOneToOne && relationship.ownerSide)
 				|| (relationship.relationshipManyToMany && relationship.ownerSide))))
 	const containsRelationshipField = relationshipFields && relationshipFields.length;
+
+	const oneToOneRelationship = relationshipFields.find(relationship => relationship.relationshipOneToOne);
 _%>
 
-export function prepare<%= entityAngularName %>PrerequisiteData() {
+export function prepare<%= entityAngularName %>PrerequisiteData(listPage = false) {
 <%_ if (containsBinaryField) { _%>
 	cy.fixture('integration-test.png').as('binaryData')
 <%_ } _%>
@@ -63,10 +65,44 @@ _%>
 	}).its('id').as('<%= relationship.relationshipName %>Id')
 	<%_
 			}
-	_%>
-	<%_
 		}
+		if (oneToOneRelationship) {
 	_%>
+	if (listPage) {
+		cy.save('api/<%= oneToOneRelationship.otherEntity.entityApiUrl %>', {
+	<%_
+		for (const relationshipField of oneToOneRelationship.otherEntity.fields.filter(field => !field.id)) {
+			const fieldValue = relationshipField.generateFakeData('cypress');
+			if (fieldValue === undefined) {
+				warning(`Error generating a value for field ${relationshipField.fieldName}`);
+			}
+	_%>
+			<%_ if (relationshipField.fieldTypeBoolean) { _%>
+			<%= relationshipField.fieldName %>: true,
+			<%_ } else if (relationshipField.fieldTypeBinary && !relationshipField.blobContentTypeText) { _%>
+			// <%= relationshipField.fieldName %>: this.binaryData,
+			<%= relationshipField.fieldName %>ContentType: 'image/png',
+			<%_ } else if (relationshipField.fieldTypeString || relationshipField.fieldTypeUUID) { _%>
+			<%= relationshipField.fieldName %>: '<%= fieldValue %>',
+			<%_ } else if (relationshipField.fieldTypeLocalDate) { _%>
+			<%= relationshipField.fieldName %>: '<%= fieldValue %>' ,
+			<%_ } else if (relationshipField.fieldTypeTimed) { _%>
+			<%= relationshipField.fieldName %>: '<%= fieldValue %>:00.000Z' ,
+			<%_ } else if (relationshipField.fieldTypeDuration) { _%>
+			<%= relationshipField.fieldName %>: 'PT0.000052484S',
+			<%_ } else if (relationshipField.fieldTypeNumeric) { _%>
+			<%= relationshipField.fieldName %>: <%= fieldValue %>,
+			<%_ } else { _%>
+			<%= relationshipField.fieldName %>: '<%= fieldValue %>',
+			<%_ } _%>
+		<%_
+			}
+		_%>
+		}).its('id').as('<%= oneToOneRelationship.relationshipName %>Id2')
+	}
+<%_
+		}
+_%>
 }
 
 export function add<%= entityAngularName %>(<%_


### PR DESCRIPTION
Closes #841 #58
--
- Move entity create and delete calls to before hook so that they are shared by tests in given spec
- Add relationship support for other entities
- In case of self referential, skip generation of test data
- Complex mandatory relationships are not covered and are not scope of code generation. We probably comment out tests to avoid generation of tests that don't execute successfully