### PR TITLE
feat: Show Swagger UI under API docs menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > All notable changes to the "generator-jhipster-svelte" project will be documented in this file.
 
+## Current
+
+### Added
+
+-   ✅ Integrate `Swagger UI` under `Administration` > `API` menu. Allows to interactively consume REST APIs [#900](https://github.com/jhipster/generator-jhipster-svelte/pull/900)
+
 ## [0.7.1] - 2022-01-03
 
 ### Changed

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -70,6 +70,12 @@ const svelteFiles = {
 			],
 		},
 	],
+	swagger: [
+		{
+			path: FRONTEND_SRC_DIR,
+			templates: ['swagger-ui/index.html'],
+		},
+	],
 	static: [
 		{
 			path: FRONTEND_SRC_DIR,
@@ -115,6 +121,7 @@ const svelteFiles = {
 				'index.svelte',
 				'admin/__layout.svelte',
 				'admin/logger.svelte',
+				'admin/docs.svelte',
 			],
 		},
 	],

--- a/generators/client/templates/svelte/package.json
+++ b/generators/client/templates/svelte/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
-		"date-fns": "2.28.0"
+		"date-fns": "2.28.0",
+		"swagger-ui-dist": "4.1.3"
 	},
 	"devDependencies": {
 		"@fortawesome/free-solid-svg-icons": "5.15.4",
@@ -28,6 +29,7 @@
 		"prettier-plugin-svelte": "2.5.1",
 		"pretty-quick": "3.1.3",
 		"rimraf": "3.0.2",
+		"rollup-plugin-copy": "3.4.0",
 		"svelte": "3.44.3",
 		"svelte-jester": "2.1.5",
 		"tailwindcss": "3.0.9"

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/layout/admin-menu.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/layout/admin-menu.svelte.ejs
@@ -3,6 +3,7 @@
 	import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers.js'
 	import { faTasks } from '@fortawesome/free-solid-svg-icons/faTasks.js'
 	import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown.js'
+	import { faBook } from '@fortawesome/free-solid-svg-icons/faBook.js'
 
 	import MenuItem from '$lib/layout/menu-item.svelte'
 	import Icon from '$lib/icon.svelte'
@@ -58,6 +59,14 @@
 		>
 			<Icon classes="sm:mr-1" icon="{faTasks}" />
 			Loggers
+		</MenuItem>
+		<MenuItem
+			testId="svlDocsLink"
+			link="/admin/docs"
+			on:click="{() => (isOpen = false)}"
+		>
+			<Icon classes="sm:mr-1" icon="{faBook}" />
+			API
 		</MenuItem>
 	</div>
 </div>

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/admin/docs.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/admin/docs.svelte.ejs
@@ -1,0 +1,21 @@
+<script>
+	import Page from '$lib/page/page.svelte'
+
+</script>
+
+<svelte:head>
+	<title>API</title>
+	<meta name="Description" content="Swagger API" />
+</svelte:head>
+<Page testId="api" width="full">
+	<iframe
+	  src="/swagger-ui/index.html"
+	  width="100%"
+	  height="900"
+	  seamless
+	  target="_top"
+	  title="Swagger UI"
+	  class="border-0"
+	  data-cy="swagger-frame"
+	></iframe>
+</Page>

--- a/generators/client/templates/svelte/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/swagger-ui/index.html.ejs
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title><%= baseName %> - Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="./swagger-ui-bundle.js"></script>
+    <script src="./swagger-ui-standalone-preset.js"></script>
+    <script src="./axios.min.js"></script>
+
+    <script type="text/javascript">
+      const AlwaysEnableTryItOutPlugin = function (system) {
+        const OperationContainer = system.getComponents('OperationContainer');
+        return {
+          components: {
+            TryItOutButton: () => null,
+            OperationContainer: class CustomOperationContainer extends OperationContainer {
+              constructor(...args) {
+                super(...args);
+                this.state.tryItOutEnabled = true;
+              }
+            },
+          },
+        };
+      };
+
+      window.onload = async function () {
+<%_ if (authenticationTypeSession || authenticationTypeOauth2) { _%>
+        function getCSRF() {
+          var name = 'XSRF-TOKEN=';
+          var ca = document.cookie.split(';');
+          for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) === ' ') c = c.substring(1);
+            if (c.indexOf(name) !== -1) return c.substring(name.length, c.length);
+          }
+          return '';
+        }
+        const axiosConfig = { timeout: 5000 };
+<%_ } else { _%>
+        const getBearerToken = () => {
+          var authToken = localStorage.getItem('authToken') || sessionStorage.getItem('authToken');
+          if (authToken) {
+            return `Bearer ${authToken}`;
+          }
+          return null;
+        };
+        const axiosConfig = {
+          headers: { timeout: 5000, Authorization: getBearerToken() },
+        };
+<%_ } _%>
+
+        const baseUrl = '/v3/api-docs';
+        let services;
+        try {
+          const response = await axios.get('/management/health/discoveryComposite', axiosConfig);
+          services = response.data?.components?.discoveryClient?.details?.services;
+          console.log(`Services`, services);
+        } catch (error) {
+          console.log(error);
+        }
+
+        let urls;
+        try {
+          if (services && services.length > 0) {
+            urls = (
+              await Promise.allSettled(
+                services.map(async service => {
+                  const response = await axios.get(`/services/${service}/management/jhiopenapigroups`, axiosConfig);
+                  if (Array.isArray(response.data)) {
+                    return response.data.map(({ group, description }) => ({
+                      name: description,
+                      url: `/services/${service}${baseUrl}/${group}`,
+                    }));
+                  }
+                  return undefined;
+                })
+              )
+            )
+              .filter(settled => settled.status === 'fulfilled')
+              .map(settled => settled.value)
+              .filter(Array.isArray)
+              .flat();
+          } else {
+            const response = await axios.get('/management/jhiopenapigroups', axiosConfig);
+            if (Array.isArray(response.data)) {
+              urls = response.data.map(({ group, description }) => ({ name: description, url: `${baseUrl}/${group}` }));
+            }
+          }
+          console.log(`Swagger urls`, urls);
+        } catch (error) {
+          console.log(error);
+        }
+
+        if (urls) {
+          urls.sort(function (a, b) {
+            var x = a.name.toLowerCase(),
+              y = b.name.toLowerCase();
+            if (x.includes('(default)')) return -1;
+            if (y.includes('(default)')) return 1;
+            if (x.includes('(management)')) return -1;
+            if (y.includes('(management)')) return 1;
+            return x < y ? -1 : x > y ? 1 : 0;
+          });
+        }
+
+        // Build a system
+        var ui = SwaggerUIBundle({
+          urls: urls,
+          url: baseUrl,
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          filter: true,
+          layout: 'StandaloneLayout',
+          withCredentials: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl, AlwaysEnableTryItOutPlugin],
+          requestInterceptor: function (req) {
+<%_ if (authenticationTypeSession || authenticationTypeOauth2) { _%>
+            req.headers['X-XSRF-TOKEN'] = getCSRF();
+<%_ } else { _%>
+            req.headers['Authorization'] = getBearerToken();
+<%_ } _%>
+            // Remove the sample Swagger UI request body if present
+            if (
+              req.method === 'GET' &&
+              req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}'
+            ) {
+              req.body = undefined;
+            }
+            return req;
+          },
+        });
+
+        window.ui = ui;
+      };
+    </script>
+  </body>
+</html>

--- a/generators/client/templates/svelte/svelte.config.js.ejs
+++ b/generators/client/templates/svelte/svelte.config.js.ejs
@@ -1,4 +1,5 @@
 import adapter from '@sveltejs/adapter-static';
+import copy from 'rollup-plugin-copy'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -37,6 +38,21 @@ const config = {
 				<%_ } _%>
 				}
 			},
+			plugins: [
+				copy({
+					targets: [
+						{
+							src: [
+								'node_modules/swagger-ui-dist/*.{js,css,html,png}',
+								'!node_modules/swagger-ui-dist/**/index.html',
+								'node_modules/axios/dist/axios.min.js',
+								'src/main/webapp/swagger-ui/index.html',
+							],
+							dest: '.svelte-kit/output/client/swagger-ui',
+						},
+					],
+				}),
+			],
 		}),
 	}
 };


### PR DESCRIPTION
Closes #895 
---
- Display Swagger UI under Admin --> API menu item (`/admin/docs`)
- Swagger integration doesn't work with the SvelteKit dev server (`npm start`).