### PR TITLE
feat: Support auth0 provider in cypress tests

### DIFF
--- a/generators/client/templates/svelte/cypress/support/commands.js.ejs
+++ b/generators/client/templates/svelte/cypress/support/commands.js.ejs
@@ -154,7 +154,8 @@ Cypress.Commands.add('getById', (url, status = 200) => {
 <%_ } else { _%>
 
 Cypress.Commands.add('loginByApi', (username, password) => {
-	cy.session([username],
+	cy.session(
+		[username],
 		() => {
 			cy.request({
 				url: '/oauth2/authorization/oidc',
@@ -162,66 +163,109 @@ Cypress.Commands.add('loginByApi', (username, password) => {
 			})
 				.its('headers.location')
 				.as('authorizeUrl')
-				.then(function(){
-					const url = new URL(this.authorizeUrl);
+				.then(function () {
+					const url = new URL(this.authorizeUrl)
 					const origin = url.origin
 
-					if(origin.includes('okta')) {
-						cy.request({
-							method: 'POST',
-							url: `${origin}/api/v1/authn`,
-							followRedirect: false,
-							body: {
-								username,
-								password,
-							},
-						})
-							.its('body.sessionToken')
-							.as('sessionToken')
-							.then(function() {
-								const sessionToken = this.sessionToken
-								cy.request({
-									url: `${this.authorizeUrl}&sessionToken=${sessionToken}`,
-									followRedirect: true,
-								})
-							})
+					if (origin.includes('okta')) {
+						oktaLogin(this.authorizeUrl, origin, username, password)
+					} else if (origin.includes('auth0')) {
+						auth0Login(origin, username, password)
 					} else {
-						cy.request({
-							url: `/oauth2/authorization/oidc`,
-							followRedirect: true,
-						})
-							.then(res => {
-								const html = document.createElement('html')
-								html.innerHTML = res.body
-								const form = html.getElementsByTagName('form')[0]
-								const url = form.action
-								return cy.request({
-									method: 'POST',
-									url,
-									followRedirect: false,
-									form: true,
-									body: {
-										username,
-										password,
-									},
-								})
-							})
-							.then(() => {
-								return cy.request({
-									url: '/oauth2/authorization/oidc',
-									followRedirect: true,
-								})
-							})
+						keycloakLogin(username, password)
 					}
 				})
-			},
+		},
 		{
 			validate() {
-				cy.request({ url: `api/account`,  failOnStatusCode: false }).its('status').should('eq', 200)
+				cy.request({ url: `api/account`, failOnStatusCode: false })
+					.its('status')
+					.should('eq', 200)
 			},
 		}
 	)
 })
+
+function auth0Login(origin, username, password) {
+	cy.request({
+		url: `/oauth2/authorization/oidc`,
+		followRedirect: true,
+	})
+		.then(res => {
+			const html = document.createElement('html')
+			html.innerHTML = res.body
+			const state = html.querySelector('input[name="state"]').value
+			return cy.request({
+				method: 'POST',
+				url: `${origin}/u/login`,
+				followRedirect: true,
+				form: true,
+				body: {
+					state,
+					action: 'default',
+					username,
+					password,
+				},
+			})
+		})
+		.then(() => {
+			cy.request({
+				url: '/oauth2/authorization/oidc',
+				followRedirect: true,
+			}).then(() => {
+				cy.visit('/')
+			})
+		})
+}
+
+function keycloakLogin(username, password) {
+	cy.request({
+		url: `/oauth2/authorization/oidc`,
+		followRedirect: true,
+	})
+		.then(res => {
+			const html = document.createElement('html')
+			html.innerHTML = res.body
+			const form = html.getElementsByTagName('form')[0]
+			const url = form.action
+			return cy.request({
+				method: 'POST',
+				url,
+				followRedirect: false,
+				form: true,
+				body: {
+					username,
+					password,
+				},
+			})
+		})
+		.then(() => {
+			return cy.request({
+				url: '/oauth2/authorization/oidc',
+				followRedirect: true,
+			})
+		})
+}
+
+function oktaLogin(authorizeUrl, origin, username, password) {
+	cy.request({
+		method: 'POST',
+		url: `${origin}/api/v1/authn`,
+		followRedirect: false,
+		body: {
+			username,
+			password,
+		},
+	})
+		.its('body.sessionToken')
+		.as('sessionToken')
+		.then(function () {
+			cy.request({
+				url: `${authorizeUrl}&sessionToken=${this.sessionToken}`,
+				followRedirect: true,
+			})
+		})
+}
 
 Cypress.Commands.add('logoutByApi', () => {
 	// cy.getCookie('XSRF-TOKEN')

--- a/package-lock.json
+++ b/package-lock.json
@@ -957,9 +957,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dependencies": {
 				"lodash": "^4.17.14"
 			}
@@ -8648,9 +8648,9 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"requires": {
 				"lodash": "^4.17.14"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3801,12 +3801,12 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"node_modules/jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.5",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
 			"dependencies": {
-				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
 			},
@@ -3814,77 +3814,13 @@
 				"jake": "bin/cli.js"
 			},
 			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/jake/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
+				"node": ">=10"
 			}
 		},
 		"node_modules/jake/node_modules/async": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-		},
-		"node_modules/jake/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/jake/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/jake/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"node_modules/jake/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/jake/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/jake/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 		},
 		"node_modules/java-parser": {
 			"version": "2.0.1",
@@ -10893,69 +10829,20 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.5",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+			"integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
 			"requires": {
-				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
 				"async": {
-					"version": "0.9.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+					"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
 				}
 			}
 		},


### PR DESCRIPTION
Closes #892 

- Support `auth0` OIDC provider in cypress e2e tests
- Refactor cypress authentication logic to move individual provider authentication logic in a separate function.