### PR TITLE
feat: Generate Gateway UI page, add CI job

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -165,6 +165,7 @@ jobs:
                         'monolithic-jwt-maven-mongodb-prod.jdl',
                         'monolithic-session-maven-postgres-prod.jdl',
                         'monolithic-oidc-maven-postgres-prod.jdl',
+                        'gateway-jwt-maven-postgres-prod.jdl',
                     ]
                 os: [ubuntu-latest]
                 node_version: [16.x]

--- a/.github/workflows/scripts/gateway-jwt-maven-postgres-prod.jdl
+++ b/.github/workflows/scripts/gateway-jwt-maven-postgres-prod.jdl
@@ -1,0 +1,11 @@
+application {
+    config {
+        baseName SampleBlogApp,
+        applicationType gateway,
+        authenticationType jwt,
+        packageName tech.jhipster.samples.blog,
+        prodDatabaseType postgresql,
+        serviceDiscoveryType eureka,
+        buildTool maven
+    }
+}

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -48,6 +48,12 @@ const svelteFiles = {
 			],
 		},
 	],
+	e2eGateway: [
+		{
+			condition: generator => generator.applicationType === 'gateway',
+			templates: ['cypress/integration/admin/gateway.spec.js'],
+		},
+	],
 	e2eLogin: [
 		{
 			condition: generator => generator.authenticationType !== 'oauth2',
@@ -132,6 +138,13 @@ const svelteFiles = {
 			templates: ['admin/docs.svelte'],
 		},
 	],
+	gatewayRoute: [
+		{
+			condition: generator => generator.applicationType === 'gateway',
+			path: FRONTEND_ROUTES_DIR,
+			templates: ['admin/gateway.svelte'],
+		},
+	],
 	loginRoutes: [
 		{
 			condition: generator => generator.authenticationType !== 'oauth2',
@@ -175,6 +188,17 @@ const svelteFiles = {
 				'layout/navbar.svelte',
 				'utils/env.js',
 				'utils/request.js',
+			],
+		},
+	],
+	libGateway: [
+		{
+			path: FRONTEND_COMPONENTS_DIR,
+			condition: generator => generator.applicationType === 'gateway',
+			templates: [
+				'admin/gateway/gateway-service.js',
+				'admin/gateway/gateway-table.svelte',
+				'admin/gateway/service-instance-table.svelte',
 			],
 		},
 	],

--- a/generators/client/templates/svelte/cypress/integration/admin/gateway.spec.js.ejs
+++ b/generators/client/templates/svelte/cypress/integration/admin/gateway.spec.js.ejs
@@ -1,0 +1,34 @@
+describe('Gateway page', () => {
+	beforeEach(() => {
+		cy.unregisterServiceWorkers()
+		cy.loginByApi(
+			Cypress.env('ADMIN_USERNAME'),
+			Cypress.env('ADMIN_PASSWORD')
+		)
+		cy.visit('/admin/gateway')
+	})
+
+	it('should greets with Gateway page title', () => {
+		cy.getBySel('gatewayTitle')
+			.should('be.visible')
+			.should('contain', 'Gateway routes')
+	})
+
+	it('should display Gateway routes table', () => {
+		cy.getBySel('gatewayTable')
+			.should('be.visible')
+			.get('tr')
+			.eq(0)
+			.children()
+			.should('have.length', 3)
+			.get('th')
+			.eq(0)
+			.should('contain', 'Service')
+			.get('th')
+			.eq(1)
+			.should('contain', 'Route')
+			.get('th')
+			.eq(2)
+			.should('contain', 'Service Instances')
+	})
+})

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/admin/gateway/gateway-service.js.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/admin/gateway/gateway-service.js.ejs
@@ -1,0 +1,6 @@
+import { serverUrl } from '$lib/utils/env'
+import { request } from '$lib/utils/request'
+
+export default {
+	fetchRoutes: () => request(`${serverUrl}api/gateway/routes/`)
+}

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/admin/gateway/gateway-table.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/admin/gateway/gateway-table.svelte.ejs
@@ -1,0 +1,37 @@
+<script>
+	import Table from 'jhipster-svelte-library/table/table.svelte'
+	import TableRow from 'jhipster-svelte-library/table/table-row.svelte'
+	import TableHeader from 'jhipster-svelte-library/table/table-header.svelte'
+	import TableData from 'jhipster-svelte-library/table/table-data.svelte'
+
+	import ServiceInstanceTable from './service-instance-table.svelte'
+
+	export let routes = []
+</script>
+
+<Table testId="gateway">
+	<thead slot="head">
+		<TableRow classes="bg-gray-100 dark:bg-gray-700">
+			<TableHeader>Service</TableHeader>
+			<TableHeader>Route</TableHeader>
+			<TableHeader>Service Instances</TableHeader>
+		</TableRow>
+	</thead>
+	<tbody>
+		{#each routes as route (route.path)}
+			<TableRow>
+				<TableData>{route.serviceId}</TableData>
+				<TableData>{route.path}</TableData>
+				<TableData>
+					<ServiceInstanceTable serviceInstances="{route.serviceInstances}" />
+				</TableData>
+			</TableRow>
+		{:else}
+			<TableRow>
+				<TableData colspan="3" classes="text-center py-8"
+					>No service routes available</TableData
+				>
+			</TableRow>
+		{/each}
+	</tbody>
+</Table>

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/admin/gateway/service-instance-table.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/admin/gateway/service-instance-table.svelte.ejs
@@ -1,0 +1,34 @@
+<script>
+	import Table from 'jhipster-svelte-library/table/table.svelte'
+	import TableRow from 'jhipster-svelte-library/table/table-row.svelte'
+	import TableData from 'jhipster-svelte-library/table/table-data.svelte'
+
+	export let serviceInstances = []
+</script>
+
+<Table classes="mt-0">
+	{#each serviceInstances as serviceInstance (serviceInstance.uri)}
+		<TableRow class="">
+			<TableData class="flex flex-row items-center">
+				<a href="{ serviceInstance.uri }" target="_blank">{ serviceInstance.uri }</a>
+				{#if serviceInstance.instanceInfo}
+					<span class="py-1 px-2 rounded ml-4 text-white { serviceInstance.instanceInfo.status === 'UP' ? 'bg-green-600' : 'bg-red-600' }">
+						{ serviceInstance.instanceInfo.status }
+					</span>
+				{:else}
+					<span class="py-1 px-2 rounded ml-4 bg-gray-500">UNKNOWN</span>
+				{/if}
+			</TableData>
+			<TableData class="w-2/3">
+				<Table class="text-sm">
+					{#each Object.entries(serviceInstance.metadata) as [key, value] (key)}
+						<TableRow classes="border-x-0 first:border-y-0 last:border-y-0">
+							<TableData class="px-1 py-1" >{ key }</TableData>
+							<TableData class="px-1 py-1  pl-4 border-l border-gray-200 dark:border-gray-700 ">{ value }</TableData>
+						</TableRow>
+					{/each}
+				</Table>
+			</TableData>
+		</TableRow>
+	{/each}
+</Table>

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/layout/admin-menu.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/layout/admin-menu.svelte.ejs
@@ -1,9 +1,19 @@
 <script>
 	import { faUsersCog } from '@fortawesome/free-solid-svg-icons/faUsersCog'
+<%_
+    if (!skipUserManagement) { _%>
 	import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
+<%_ } _%>
 	import { faTasks } from '@fortawesome/free-solid-svg-icons/faTasks'
 	import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown'
+<%_
+if (this.blueprintConfig.swaggerUi) { _%>
 	import { faBook } from '@fortawesome/free-solid-svg-icons/faBook'
+<%_ } _%>
+<%_
+    if (applicationType === 'gateway') { _%>
+	import { faRoad } from '@fortawesome/free-solid-svg-icons/faRoad'
+<%_ } _%>
 	import MenuItem from 'jhipster-svelte-library/layout/menu-item.svelte'
 
 	import Icon from 'jhipster-svelte-library/icon.svelte'
@@ -41,6 +51,17 @@
 		class:hidden="{!isOpen}"
 		class="sm:absolute sm:right-0 sm:mt-10 sm:w-48 py-2 sm:bg-white sm:dark:bg-gray-700 rounded sm:rounded-lg sm:shadow-lg"
 	>
+        <%_
+        if (applicationType === 'gateway') { _%>
+		<MenuItem
+			testId="svlGatewayLink"
+			link="/admin/gateway"
+			on:click="{() => (isOpen = false)}"
+		>
+			<Icon classes="sm:mr-1" icon="{faRoad}" />
+			Gateway
+		</MenuItem>
+        <%_ } _%>
 		<%_
 		if (!skipUserManagement) { _%>
 		<MenuItem

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/admin/gateway.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/admin/gateway.svelte.ejs
@@ -1,0 +1,42 @@
+<script>
+	import { onMount } from 'svelte'
+	import Page from 'jhipster-svelte-library/page/page.svelte'
+
+	import gatewayService from '$lib/admin/gateway/gateway-service'
+	import GatewayTable from '$lib/admin/gateway/gateway-table.svelte'
+
+	let error
+	let page
+	let loading = true
+	let routes = []
+
+	onMount(() => fetchRoutes())
+
+	function fetchRoutes() {
+		loading = true
+		error = undefined
+		gatewayService
+			.fetchRoutes()
+			.then(res => routes = res)
+			.catch(err => (error = err))
+			.finally(() => (loading = false))
+	}
+</script>
+
+<svelte:head>
+	<title>Gateway Routes</title>
+	<meta name="Description" content="Gateway routes" />
+</svelte:head>
+<Page testId="gateway" width="full">
+	<div
+		class="text-left flex flex-row justify-between items-center"
+		slot="header"
+	>
+		<span>Gateway routes</span>
+	</div>
+	{#if !loading}
+		<GatewayTable
+			routes="{routes}"
+		/>
+	{/if}
+</Page>


### PR DESCRIPTION
Related #530 

---

- Under `Administration` menu, generate a new `Gateway` page showing micro-services path, instances and metadata
- Add new CI job to verify the `gateway` type applications
- Add conditionals to avoid redundant icon imports  