### PR TITLE
chore: Bump svelte/kit and other dependencies

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -58,7 +58,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install google-chrome-stable -y
                   sudo apt-get install xvfb
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node_version }}
             - name: Gradle - Configure cache
@@ -79,9 +79,9 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: |
-                      ~/.cache/Cypress/10.6.x
+                      ~/.cache/Cypress/10.7.x
                       ~/.cache/Cypress/cy
-                  key: ${{ runner.os }}-cypress-10.6.x
+                  key: ${{ runner.os }}-cypress-10.7.x
             - name: Retrieve saved Svelte Docker Image
               uses: actions/download-artifact@v2
               with:
@@ -168,7 +168,7 @@ jobs:
                         'gateway-jwt-maven-postgres-prod.jdl',
                     ]
                 os: [ubuntu-latest]
-                node_version: [16.x]
+                node_version: [16.16]
         steps:
             - uses: actions/checkout@v2
             - name: Download latest chrome binary
@@ -201,9 +201,9 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: |
-                      ~/.cache/Cypress/10.6.x
+                      ~/.cache/Cypress/10.7.x
                       ~/.cache/Cypress/cy
-                  key: ${{ runner.os }}-cypress-10.6.x
+                  key: ${{ runner.os }}-cypress-10.7.x
             - name: Retrieve saved Svelte Docker Image
               uses: actions/download-artifact@v2
               with:
@@ -321,9 +321,9 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: |
-                      ~/.cache/Cypress/10.6.x
+                      ~/.cache/Cypress/10.7.x
                       ~/.cache/Cypress/cy
-                  key: ${{ runner.os }}-cypress-10.6.x
+                  key: ${{ runner.os }}-cypress-10.7.x
             - name: Retrieve saved Svelte Docker Image
               uses: actions/download-artifact@v2
               with:
@@ -461,9 +461,9 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: |
-                      ~/.cache/Cypress/10.6.x
+                      ~/.cache/Cypress/10.7.x
                       ~/.cache/Cypress/cy
-                  key: ${{ runner.os }}-cypress-10.6.x
+                  key: ${{ runner.os }}-cypress-10.7.x
             - name: Retrieve saved Svelte Docker Image
               uses: actions/download-artifact@v2
               with:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -49,7 +49,7 @@ jobs:
                         'monolithic-session-maven-reactive.jdl',
                     ]
                 os: [ubuntu-latest]
-                node_version: [16.x]
+                node_version: [16.16]
         steps:
             - uses: actions/checkout@v2
             - name: Download latest chrome binary
@@ -288,7 +288,7 @@ jobs:
             matrix:
                 apps: ['microservices-oidc-maven-prod.jdl']
                 os: [ubuntu-latest]
-                node_version: [16.x]
+                node_version: [16.16]
         steps:
             - uses: actions/checkout@v2
             - name: Download latest chrome binary
@@ -434,7 +434,7 @@ jobs:
             matrix:
                 apps: ['svelte-app-session-lighthouse.jdl']
                 os: [ubuntu-latest]
-                node_version: [16.x]
+                node_version: [16.16]
         steps:
             - uses: actions/checkout@v2
               with:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -16,7 +16,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node_version: [14.x, 16.x]
+                node_version: [16.16]
                 os: [ubuntu-latest]
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
               uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: '16.x'
+                  node-version: '16.16'
                   registry-url: 'https://registry.npmjs.org'
             - run: npm install
             - run: npm publish

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -17,10 +17,13 @@ module.exports = class extends AppGenerator {
 			defaults: false,
 		});
 
+		if (!this.blueprintConfig) {
+			this.blueprintConfig = {};
+		}
+
 		if (this.options.swaggerUi) {
 			this.blueprintConfig.swaggerUi = this.options.swaggerUi;
-		} else if (!this.blueprintConfig) {
-			this.blueprintConfig = {};
+		} else {
 			this.blueprintConfig.swaggerUi = false;
 		}
 	}
@@ -90,6 +93,8 @@ module.exports = class extends AppGenerator {
 
 	get prompting() {
 		const defaultPhaseFromJHipster = super._prompting();
+		this.log('app prompt priority ' + this.oldVersion);
+
 		return {
 			...defaultPhaseFromJHipster,
 			askForApplicationType: prompts.askForApplicationType,
@@ -97,7 +102,13 @@ module.exports = class extends AppGenerator {
 	}
 
 	get configuring() {
-		return super._configuring();
+		return {
+			...super._configuring(),
+			config() {
+				this.jhipsterContext.configOptions.oldSvelteBlueprintVersion = this.blueprintConfig.version;
+				this.blueprintConfig.version = this.blueprintjs.version;
+			},
+		};
 	}
 
 	get composing() {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -93,7 +93,6 @@ module.exports = class extends AppGenerator {
 
 	get prompting() {
 		const defaultPhaseFromJHipster = super._prompting();
-		this.log('app prompt priority ' + this.oldVersion);
 
 		return {
 			...defaultPhaseFromJHipster,

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -124,11 +124,11 @@ const svelteFiles = {
 		{
 			path: FRONTEND_ROUTES_DIR,
 			templates: [
-				'__error.svelte',
-				'__layout.svelte',
-				'index.svelte',
-				'admin/__layout.svelte',
-				'admin/logger.svelte',
+				{ file: () => `__error.svelte`, renameTo: () => `+error.svelte` },
+				{ file: () => `__layout.svelte`, renameTo: () => `+layout.svelte` },
+				{ file: () => `index.svelte`, renameTo: () => `+page.svelte` },
+				{ file: () => `admin/__layout.svelte`, renameTo: () => `admin/+layout.svelte` },
+				{ file: () => `admin/logger.svelte`, renameTo: () => `admin/logger/+page.svelte` },
 			],
 		},
 	],
@@ -136,21 +136,21 @@ const svelteFiles = {
 		{
 			condition: generator => generator.blueprintConfig.swaggerUi,
 			path: FRONTEND_ROUTES_DIR,
-			templates: ['admin/docs.svelte'],
+			templates: [{ file: () => `admin/docs.svelte`, renameTo: () => `admin/docs/+page.svelte` }],
 		},
 	],
 	gatewayRoute: [
 		{
 			condition: generator => generator.applicationType === 'gateway',
 			path: FRONTEND_ROUTES_DIR,
-			templates: ['admin/gateway.svelte'],
+			templates: [{ file: () => `admin/gateway.svelte`, renameTo: () => `admin/gateway/+page.svelte` }],
 		},
 	],
 	loginRoutes: [
 		{
 			condition: generator => generator.authenticationType !== 'oauth2',
 			path: FRONTEND_ROUTES_DIR,
-			templates: ['login.svelte'],
+			templates: [{ file: () => `login.svelte`, renameTo: () => `login/+page.svelte` }],
 		},
 	],
 	routesUserManagement: [
@@ -158,16 +158,28 @@ const svelteFiles = {
 			condition: generator => !generator.skipUserManagement && generator.authenticationType !== 'oauth2',
 			path: FRONTEND_ROUTES_DIR,
 			templates: [
-				'account/activate.svelte',
-				'account/password.svelte',
-				'account/register.svelte',
-				'account/settings.svelte',
-				'account/reset/finish.svelte',
-				'account/reset/init.svelte',
-				'admin/user-management/index.svelte',
-				'admin/user-management/new.svelte',
-				'admin/user-management/[id]/edit.svelte',
-				'admin/user-management/[id]/view.svelte',
+				{ file: () => `account/activate.svelte`, renameTo: () => `account/activate/+page.svelte` },
+				{ file: () => `account/password.svelte`, renameTo: () => `account/password/+page.svelte` },
+				{ file: () => `account/register.svelte`, renameTo: () => `account/register/+page.svelte` },
+				{ file: () => `account/settings.svelte`, renameTo: () => `account/settings/+page.svelte` },
+				{ file: () => `account/reset/finish.svelte`, renameTo: () => `account/reset/finish/+page.svelte` },
+				{ file: () => `account/reset/init.svelte`, renameTo: () => `account/reset/init/+page.svelte` },
+				{
+					file: () => `admin/user-management/index.svelte`,
+					renameTo: () => `admin/user-management/+page.svelte`,
+				},
+				{
+					file: () => `admin/user-management/new.svelte`,
+					renameTo: () => `admin/user-management/new/+page.svelte`,
+				},
+				{
+					file: () => `admin/user-management/[id]/edit.svelte`,
+					renameTo: () => `admin/user-management/[id]/edit/+page.svelte`,
+				},
+				{
+					file: () => `admin/user-management/[id]/view.svelte`,
+					renameTo: () => `admin/user-management/[id]/view/+page.svelte`,
+				},
 			],
 		},
 	],

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -18,7 +18,6 @@ module.exports = class extends ClientGenerator {
 		}
 
 		this.blueprintjs = blueprintPackageJson;
-		console.log('blueprint old....' + this.jhipsterContext.configOptions.oldSvelteBlueprintVersion);
 
 		this.skipServer = this.config.get('skipServer') || false;
 		this.skipClient = this.config.get('skipClient') || false;

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -77,6 +77,88 @@ module.exports = class extends ClientGenerator {
 			cleanup() {
 				this.removeFile(`${constants.ANGULAR_DIR}/lib/admin/user-management/user-delete-modal.svelte`);
 				this.removeFile(`cypress.json`);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/__error.svelte`,
+					`${constants.ANGULAR_DIR}/routes/+error.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/__layout.svelte`,
+					`${constants.ANGULAR_DIR}/routes/+layout.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/index.svelte`,
+					`${constants.ANGULAR_DIR}/routes/+page.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/admin/__layout.svelte`,
+					`${constants.ANGULAR_DIR}/routes/admin/+layout.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/admin/logger.svelte`,
+					`${constants.ANGULAR_DIR}/routes/admin/logger/+page.svelte`
+				);
+
+				if (this.blueprintConfig.swaggerUi) {
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/admin/docs.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/docs/+page.svelte`
+					);
+				}
+				if (this.applicationType === 'gateway') {
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/admin/gateway.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/gateway/+page.svelte`
+					);
+				}
+				if (this.authenticationType !== 'oauth2') {
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/login.svelte`,
+						`${constants.ANGULAR_DIR}/routes/login/+page.svelte`
+					);
+				}
+				if (!this.skipUserManagement && this.authenticationType !== 'oauth2') {
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/account/activate.svelte`,
+						`${constants.ANGULAR_DIR}/routes/account/activate/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/account/password.svelte`,
+						`${constants.ANGULAR_DIR}/routes/account/password/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/account/register.svelte`,
+						`${constants.ANGULAR_DIR}/routes/account/register/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/account/settings.svelte`,
+						`${constants.ANGULAR_DIR}/routes/account/settings/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/account/reset/finish.svelte`,
+						`${constants.ANGULAR_DIR}/routes/account/reset/finish/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/account/reset/init.svelte`,
+						`${constants.ANGULAR_DIR}/routes/account/reset/init/+page.svelte`
+					);
+
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/index.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/new.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/new/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/edit.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/edit/+page.svelte`
+					);
+					this.gitMove(
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/view.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/view/+page.svelte`
+					);
+				}
 			},
 			writeAdditionalFile() {
 				writeFiles.call(this);

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -3,6 +3,7 @@ const ClientGenerator = require('generator-jhipster/generators/client');
 const constants = require('generator-jhipster/generators/generator-constants');
 const writeFiles = require('./files').writeFiles;
 const blueprintPackageJson = require('../../package.json');
+const util = require('../util');
 
 module.exports = class extends ClientGenerator {
 	constructor(args, opts) {
@@ -17,6 +18,8 @@ module.exports = class extends ClientGenerator {
 		}
 
 		this.blueprintjs = blueprintPackageJson;
+		console.log('blueprint old....' + this.jhipsterContext.configOptions.oldSvelteBlueprintVersion);
+
 		this.skipServer = this.config.get('skipServer') || false;
 		this.skipClient = this.config.get('skipClient') || false;
 	}
@@ -75,89 +78,110 @@ module.exports = class extends ClientGenerator {
 	get writing() {
 		return {
 			cleanup() {
-				this.removeFile(`${constants.ANGULAR_DIR}/lib/admin/user-management/user-delete-modal.svelte`);
-				this.removeFile(`cypress.json`);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/__error.svelte`,
-					`${constants.ANGULAR_DIR}/routes/+error.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/__layout.svelte`,
-					`${constants.ANGULAR_DIR}/routes/+layout.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/index.svelte`,
-					`${constants.ANGULAR_DIR}/routes/+page.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/admin/__layout.svelte`,
-					`${constants.ANGULAR_DIR}/routes/admin/+layout.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/admin/logger.svelte`,
-					`${constants.ANGULAR_DIR}/routes/admin/logger/+page.svelte`
-				);
-
-				if (this.blueprintConfig.swaggerUi) {
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/admin/docs.svelte`,
-						`${constants.ANGULAR_DIR}/routes/admin/docs/+page.svelte`
+				if (util.isVersionLessThan(this, '0.10.0')) {
+					this.removeFile(`${constants.ANGULAR_DIR}/lib/admin/user-management/user-delete-modal.svelte`);
+					this.removeFile(`cypress.json`);
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/__error.svelte`,
+						`${constants.ANGULAR_DIR}/routes/+error.svelte`
 					);
-				}
-				if (this.applicationType === 'gateway') {
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/admin/gateway.svelte`,
-						`${constants.ANGULAR_DIR}/routes/admin/gateway/+page.svelte`
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/__layout.svelte`,
+						`${constants.ANGULAR_DIR}/routes/+layout.svelte`
 					);
-				}
-				if (this.authenticationType !== 'oauth2') {
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/login.svelte`,
-						`${constants.ANGULAR_DIR}/routes/login/+page.svelte`
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/index.svelte`,
+						`${constants.ANGULAR_DIR}/routes/+page.svelte`
 					);
-				}
-				if (!this.skipUserManagement && this.authenticationType !== 'oauth2') {
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/account/activate.svelte`,
-						`${constants.ANGULAR_DIR}/routes/account/activate/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/account/password.svelte`,
-						`${constants.ANGULAR_DIR}/routes/account/password/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/account/register.svelte`,
-						`${constants.ANGULAR_DIR}/routes/account/register/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/account/settings.svelte`,
-						`${constants.ANGULAR_DIR}/routes/account/settings/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/account/reset/finish.svelte`,
-						`${constants.ANGULAR_DIR}/routes/account/reset/finish/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/account/reset/init.svelte`,
-						`${constants.ANGULAR_DIR}/routes/account/reset/init/+page.svelte`
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/admin/__layout.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/+layout.svelte`
 					);
 
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/index.svelte`,
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/+page.svelte`
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/admin/logger.svelte`,
+						`${constants.ANGULAR_DIR}/routes/admin/logger/+page.svelte`
 					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/new.svelte`,
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/new/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/edit.svelte`,
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/edit/+page.svelte`
-					);
-					this.gitMove(
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/view.svelte`,
-						`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/view/+page.svelte`
-					);
+
+					if (this.blueprintConfig.swaggerUi) {
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/admin/docs.svelte`,
+							`${constants.ANGULAR_DIR}/routes/admin/docs/+page.svelte`
+						);
+					}
+					if (this.applicationType === 'gateway') {
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/admin/gateway.svelte`,
+							`${constants.ANGULAR_DIR}/routes/admin/gateway/+page.svelte`
+						);
+					}
+					if (this.authenticationType !== 'oauth2') {
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/login.svelte`,
+							`${constants.ANGULAR_DIR}/routes/login/+page.svelte`
+						);
+					}
+					if (!this.skipUserManagement && this.authenticationType !== 'oauth2') {
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/account/activate.svelte`,
+							`${constants.ANGULAR_DIR}/routes/account/activate/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/account/password.svelte`,
+							`${constants.ANGULAR_DIR}/routes/account/password/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/account/register.svelte`,
+							`${constants.ANGULAR_DIR}/routes/account/register/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/account/settings.svelte`,
+							`${constants.ANGULAR_DIR}/routes/account/settings/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/account/reset/finish.svelte`,
+							`${constants.ANGULAR_DIR}/routes/account/reset/finish/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/account/reset/init.svelte`,
+							`${constants.ANGULAR_DIR}/routes/account/reset/init/+page.svelte`
+						);
+
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/index.svelte`,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/new.svelte`,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/new/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/edit.svelte`,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/edit/+page.svelte`
+						);
+						util.moveFile(
+							this,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/view.svelte`,
+							`${constants.ANGULAR_DIR}/routes/admin/user-management/[id]/view/+page.svelte`
+						);
+					}
 				}
 			},
 			writeAdditionalFile() {

--- a/generators/client/templates/svelte/package.json
+++ b/generators/client/templates/svelte/package.json
@@ -3,15 +3,15 @@
 		"date-fns": "2.29.2"
 	},
 	"devDependencies": {
-		"@fortawesome/free-solid-svg-icons": "6.1.2",
-		"@sveltejs/adapter-static": "1.0.0-next.39",
-		"@sveltejs/kit": "1.0.0-next.405",
+		"@fortawesome/free-solid-svg-icons": "6.2.0",
+		"@sveltejs/adapter-static": "1.0.0-next.40",
+		"@sveltejs/kit": "1.0.0-next.456",
 		"@testing-library/jest-dom": "5.16.5",
 		"@testing-library/svelte": "3.2.1",
 		"autoprefixer": "10.4.8",
 		"cross-env": "7.0.3",
-		"cypress": "10.6.0",
-		"esbuild": "0.15.5",
+		"cypress": "10.7.0",
+		"esbuild": "0.15.6",
 		"eslint": "8.23.0",
 		"eslint-plugin-cypress": "2.12.1",
 		"eslint-plugin-jest-dom": "4.0.2",
@@ -23,7 +23,7 @@
 		"jest-junit": "14.0.1",
 		"jest-sonar": "0.2.12",
 		"jest-svelte-resolver": "1.0.0",
-		"jhipster-svelte-library": "0.8.0",
+		"jhipster-svelte-library": "0.9.1",
 		"postcss": "8.4.16",
 		"prettier": "2.7.1",
 		"prettier-plugin-svelte": "2.7.0",
@@ -33,6 +33,6 @@
 		"svelte": "3.49.0",
 		"svelte-jester": "2.3.2",
 		"tailwindcss": "3.1.8",
-		"vite": "3.0.9"
+		"vite": "3.1.0-beta.1"
 	}
 }

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/account/account-menu.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/account/account-menu.svelte.ejs
@@ -1,7 +1,7 @@
 <script>
 	import { goto } from '$app/navigation'
 <%_ if (authenticationType === 'oauth2') { _%>
-	import { browser } from '$app/env'
+	import { browser } from '$app/environment'
 <%_ } _%>
 	import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt'
 <%_ if (authenticationType !== 'oauth2' && !skipUserManagement) { _%>

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/admin/user-management/user-form.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/admin/user-management/user-form.svelte.ejs
@@ -166,7 +166,7 @@
 			data: authorities.map(authority => ({
 				name: authority,
 				value: authority,
-			}))
+			})),
 		}}"
 		on:validate="{event => {
 			validAuthorities = event.detail.valid

--- a/generators/client/templates/svelte/src/main/webapp/app/lib/auth/auth-guard.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/lib/auth/auth-guard.svelte.ejs
@@ -1,7 +1,7 @@
 <script>
 	import { goto } from '$app/navigation'
 <%_ if (authenticationType === 'oauth2') { _%>
-	import { browser } from '$app/env'
+	import { browser } from '$app/environment'
 <%_ } _%>
 	import { page } from '$app/stores'
 	import { onMount } from 'svelte'
@@ -23,14 +23,16 @@
 
 	$: routeAccessAllowed =
 		($auth && $auth.login) ||
-		($page && $page.url &&
+		($page &&
+			$page.url &&
 			[...allowedUnAuthenticatedRoutes, '/'].includes($page.url.pathname))
 
 	function checkIfCurrentRouteAccessNotAllowed() {
 		if (
 			$auth &&
 			$auth.login &&
-			$page && $page.url &&
+			$page &&
+			$page.url &&
 			allowedUnAuthenticatedRoutes.includes($page.url.pathname)
 		) {
 			goto('/')
@@ -44,7 +46,13 @@
 			}
 <%_ } _%>
 		} else {
-			if ($auth && $auth.login && $page && $page.url && $page.url.pathname === '/') {
+			if (
+				$auth &&
+				$auth.login &&
+				$page &&
+				$page.url &&
+				$page.url.pathname === '/'
+			) {
 				const savedRoute = auth.getSavedRoute();
 				if (savedRoute) {
 					goto(savedRoute)

--- a/generators/client/templates/svelte/src/main/webapp/app/routes/__layout.svelte.ejs
+++ b/generators/client/templates/svelte/src/main/webapp/app/routes/__layout.svelte.ejs
@@ -2,7 +2,7 @@
 <%_ if (authenticationType !== 'oauth2') { _%>
 	import { page } from '$app/stores'
 <%_ } _%>
-	import { browser } from '$app/env'
+	import { browser } from '$app/environment'
 
 	import AuthGuard from '$lib/auth/auth-guard.svelte'
 	import Footer from '$lib/layout/footer.svelte'

--- a/generators/client/templates/svelte/svelte.config.js.ejs
+++ b/generators/client/templates/svelte/svelte.config.js.ejs
@@ -19,7 +19,7 @@ const config = {
 			lib: '<%= CLIENT_MAIN_SRC_DIR %>app/lib',
 			routes: '<%= CLIENT_MAIN_SRC_DIR %>app/routes',
 			serviceWorker: '<%= CLIENT_MAIN_SRC_DIR %>app/service-worker',
-			template: '<%= CLIENT_MAIN_SRC_DIR %>app/app.html'
+			appTemplate: '<%= CLIENT_MAIN_SRC_DIR %>app/app.html'
 		},
 	}
 };

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -18,19 +18,19 @@ const svelteFiles = {
 			templates: [
 				{
 					file: 'entity/index.svelte',
-					renameTo: generator => `${generator.entityFolderName}/index.svelte`,
+					renameTo: generator => `${generator.entityFolderName}/+page.svelte`,
 				},
 				{
 					file: 'entity/new.svelte',
-					renameTo: generator => `${generator.entityFolderName}/new.svelte`,
+					renameTo: generator => `${generator.entityFolderName}/new/+page.svelte`,
 				},
 				{
 					file: 'entity/[id]/view.svelte',
-					renameTo: generator => `${generator.entityFolderName}/[id]/view.svelte`,
+					renameTo: generator => `${generator.entityFolderName}/[id]/view/+page.svelte`,
 				},
 				{
 					file: 'entity/[id]/edit.svelte',
-					renameTo: generator => `${generator.entityFolderName}/[id]/edit.svelte`,
+					renameTo: generator => `${generator.entityFolderName}/[id]/edit/+page.svelte`,
 				},
 			],
 		},

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -59,6 +59,22 @@ module.exports = class extends EntityClientGenerator {
 				this.removeFile(
 					`${constants.ANGULAR_DIR}/lib/entities/${this.entityFolderName}/${this.entityFileName}-list-actions.svelte`
 				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/index.svelte`,
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/+page.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/new.svelte`,
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/new/+page.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/view.svelte`,
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/view/+page.svelte`
+				);
+				this.gitMove(
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/edit.svelte`,
+					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/edit/+page.svelte`
+				);
 			},
 			writeAdditionalFile() {
 				writeFiles.call(this);

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -3,6 +3,7 @@ const EntityClientGenerator = require('generator-jhipster/generators/entity-clie
 const constants = require('generator-jhipster/generators/generator-constants');
 const writeFiles = require('./files').writeFiles;
 const blueprintPackageJson = require('../../package.json');
+const util = require('../util');
 
 module.exports = class extends EntityClientGenerator {
 	constructor(args, opts) {
@@ -53,28 +54,34 @@ module.exports = class extends EntityClientGenerator {
 	get writing() {
 		return {
 			cleanup() {
-				this.removeFile(
-					`${constants.ANGULAR_DIR}/lib/entities/${this.entityFolderName}/${this.entityFileName}-delete-modal.svelte`
-				);
-				this.removeFile(
-					`${constants.ANGULAR_DIR}/lib/entities/${this.entityFolderName}/${this.entityFileName}-list-actions.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/index.svelte`,
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/+page.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/new.svelte`,
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/new/+page.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/view.svelte`,
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/view/+page.svelte`
-				);
-				this.gitMove(
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/edit.svelte`,
-					`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/edit/+page.svelte`
-				);
+				if (util.isVersionLessThan(this, '0.10.0')) {
+					this.removeFile(
+						`${constants.ANGULAR_DIR}/lib/entities/${this.entityFolderName}/${this.entityFileName}-delete-modal.svelte`
+					);
+					this.removeFile(
+						`${constants.ANGULAR_DIR}/lib/entities/${this.entityFolderName}/${this.entityFileName}-list-actions.svelte`
+					);
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/index.svelte`,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/+page.svelte`
+					);
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/new.svelte`,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/new/+page.svelte`
+					);
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/view.svelte`,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/view/+page.svelte`
+					);
+					util.moveFile(
+						this,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/edit.svelte`,
+						`${constants.ANGULAR_DIR}/routes/entities/${this.entityFolderName}/[id]/edit/+page.svelte`
+					);
+				}
 			},
 			writeAdditionalFile() {
 				writeFiles.call(this);

--- a/generators/util.js
+++ b/generators/util.js
@@ -1,10 +1,13 @@
 const jhipsterUtils = require('generator-jhipster/generators/utils');
 const constants = require('generator-jhipster/generators/generator-constants');
+const semver = require('semver');
 
 const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 
 module.exports = {
 	addEntityToMenu,
+	isVersionLessThan,
+	moveFile,
 };
 
 function addEntityToMenu(generator, entityRoute, entityName, entityClass) {
@@ -26,4 +29,14 @@ function addEntityToMenu(generator, entityRoute, entityName, entityClass) {
 		},
 		generator
 	);
+}
+
+function isVersionLessThan(generator, version) {
+	const oldVersion = generator.jhipsterContext.configOptions.oldSvelteBlueprintVersion;
+	return oldVersion ? semver.lt(oldVersion, version) : false;
+}
+
+function moveFile(generator, source, destination) {
+	generator.log(`Renaming file - ${source} to ${destination}`);
+	generator.fs.move(source, destination, { noGlob: true });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"prettier": "2.7.1",
 				"prettier-plugin-svelte": "2.7.0",
 				"pretty-quick": "3.1.3",
+				"semver": "7.3.7",
 				"yeoman-assert": "3.1.1",
 				"yeoman-test": "6.3.0"
 			}
@@ -3017,6 +3018,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/generator-jhipster/node_modules/semver": {
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/get-caller-file": {
@@ -6351,9 +6366,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -10397,6 +10412,14 @@
 					"version": "2.6.2",
 					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
 					"integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew=="
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				}
 			}
 		},
@@ -12844,9 +12867,9 @@
 			"integrity": "sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ=="
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-jhipster-svelte",
-	"version": "0.10.0",
+	"version": "0.9.0",
 	"description": "A svelte.js blueprint to generate cybernetically enhanced web applications.",
 	"keywords": [
 		"yeoman-generator",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 	},
 	"dependencies": {
 		"chalk": "4.1.2",
-		"generator-jhipster": "7.8.1"
+		"generator-jhipster": "7.8.1",
+		"semver": "7.3.7"
 	},
 	"devDependencies": {
 		"ejs-lint": "1.2.2",
@@ -52,7 +53,6 @@
 		"prettier": "2.7.1",
 		"prettier-plugin-svelte": "2.7.0",
 		"pretty-quick": "3.1.3",
-		"semver": "7.3.7",
 		"yeoman-assert": "3.1.1",
 		"yeoman-test": "6.3.0"
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generator-jhipster-svelte",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "A svelte.js blueprint to generate cybernetically enhanced web applications.",
 	"keywords": [
 		"yeoman-generator",
@@ -52,6 +52,7 @@
 		"prettier": "2.7.1",
 		"prettier-plugin-svelte": "2.7.0",
 		"pretty-quick": "3.1.3",
+		"semver": "7.3.7",
 		"yeoman-assert": "3.1.1",
 		"yeoman-test": "6.3.0"
 	}


### PR DESCRIPTION
- Store blueprint version to be reused during cleanup activity.
- Bump svelte/kit dependency to incorporate breaking changes
- Bump cypress dependency and fix node version in CI to `16.16` due to cypress issue