### PR TITLE
test: fixed e2e tests for microservices oauth.

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -553,7 +553,7 @@ jobs:
                   docker compose up -d
                   timeout 180 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8080/api/authenticate)" != "200" ]]; do sleep 5; done' || false
                   cd "$HOME/svelte-ms/gateway"
-                  # npm run e2e:ci
+                  npm run e2e:ci
     lighthouse-job:
         needs: svelte-image
         name: ${{ matrix.apps }}

--- a/generators/client/templates/cypress/support/commands.js.ejs
+++ b/generators/client/templates/cypress/support/commands.js.ejs
@@ -184,7 +184,7 @@ Cypress.Commands.add('loginByApi', (username, password) => {
 					.its('status')
 					.should('eq', 200)
 			},
-			cacheAcrossSpecs: true,
+			cacheAcrossSpecs: false,
 		}
 	)
 })


### PR DESCRIPTION
Close #2076 

Hi @vishal423 
The e2e tests failed even on the local machine, but after clearing the `restored` session, it works.

1. https://docs.cypress.io/api/commands/session#Explicitly-clearing-sessions
2. https://github.com/cypress-io/cypress/issues/26028