### PR TITLE
Add Playwright e2e option

### DIFF
--- a/generators/client/command.js
+++ b/generators/client/command.js
@@ -11,6 +11,11 @@ const command = {
 			type: Boolean,
 			scope: 'blueprint',
 		},
+		playwright: {
+			description: 'Generate Playwright UI end-to-end tests instead of Cypress',
+			type: Boolean,
+			scope: 'blueprint',
+		},
 	},
 };
 

--- a/generators/client/entity-files.js
+++ b/generators/client/entity-files.js
@@ -53,6 +53,7 @@ export default {
 	],
 	entityE2eTests: [
 		{
+			condition: generator => !generator.playwright,
 			templates: [
 				{
 					file: 'cypress/integration/entities/entity/entity-delete.spec.js',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -12,7 +12,6 @@ const svelteFiles = {
 				'.npmrc',
 				'.gitignore.jhi.svelte',
 				'.prettierignore.jhi.svelte',
-				'cypress.config.cjs',
 				'eslint.config.js',
 				'README.md.jhi.svelte',
 				{
@@ -27,8 +26,21 @@ const svelteFiles = {
 			],
 		},
 	],
+	cypressBase: [
+		{
+			condition: generator => !generator.playwright,
+			templates: ['cypress.config.cjs'],
+		},
+	],
+	playwrightBase: [
+		{
+			condition: generator => generator.playwright,
+			templates: ['playwright.config.js'],
+		},
+	],
 	e2e: [
 		{
+			condition: generator => !generator.playwright,
 			templates: [
 				{
 					file: generator => `${FRONTEND_SRC_DIR}static/content/img/${generator.hipster}_head-192.png`,
@@ -45,22 +57,36 @@ const svelteFiles = {
 				'cypress/support/commands.js',
 			],
 		},
+		{
+			condition: generator => generator.playwright,
+			templates: [
+				'playwright/support/test-utils.js',
+				'playwright/e2e/home.spec.js',
+				'playwright/e2e/navbar.spec.js',
+				'playwright/e2e/routes.spec.js',
+			],
+		},
 	],
 	e2eGateway: [
 		{
-			condition: generator => generator.applicationType === 'gateway',
+			condition: generator => generator.applicationType === 'gateway' && !generator.playwright,
 			templates: ['cypress/integration/admin/gateway.spec.js'],
 		},
 	],
 	e2eLogin: [
 		{
-			condition: generator => generator.authenticationType !== 'oauth2',
+			condition: generator => generator.authenticationType !== 'oauth2' && !generator.playwright,
 			templates: ['cypress/integration/login.spec.js'],
+		},
+		{
+			condition: generator => generator.authenticationType !== 'oauth2' && generator.playwright,
+			templates: ['playwright/e2e/login.spec.js'],
 		},
 	],
 	e2eUserManagement: [
 		{
-			condition: generator => !generator.skipUserManagement && generator.authenticationType !== 'oauth2',
+			condition: generator =>
+				!generator.skipUserManagement && generator.authenticationType !== 'oauth2' && !generator.playwright,
 			templates: [
 				'cypress/integration/account/change-password.spec.js',
 				'cypress/integration/account/register.spec.js',
@@ -72,6 +98,11 @@ const svelteFiles = {
 				'cypress/integration/admin/user-management/user-update.spec.js',
 				'cypress/integration/admin/user-management/user-view.spec.js',
 			],
+		},
+		{
+			condition: generator =>
+				!generator.skipUserManagement && generator.authenticationType !== 'oauth2' && generator.playwright,
+			templates: ['playwright/e2e/account/register.spec.js'],
 		},
 	],
 	swagger: [

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -58,11 +58,15 @@ export default class extends ClientGenerator {
 					if (this.blueprintConfig.jest === undefined) {
 						this.blueprintConfig.jest = false;
 					}
+					if (this.blueprintConfig.playwright === undefined) {
+						this.blueprintConfig.playwright = false;
+					}
 				}
 			},
 			setLocalCommandOptions() {
 				this.jest = this.blueprintConfig.jest;
 				this.swaggerUi = this.blueprintConfig.swaggerUi;
+				this.playwright = this.blueprintConfig.playwright;
 			},
 		});
 	}
@@ -212,7 +216,12 @@ export default class extends ClientGenerator {
 			async writingTemplateTask({ application }) {
 				await this.writeFiles({
 					sections: svelteFiles,
-					context: { ...application, swaggerUi: this.swaggerUi, jest: this.jest },
+					context: {
+						...application,
+						swaggerUi: this.swaggerUi,
+						jest: this.jest,
+						playwright: this.playwright,
+					},
 				});
 			},
 		});
@@ -253,7 +262,13 @@ export default class extends ClientGenerator {
 				for (const entity of entities.filter(entity => !entity.skipClient && !entity.builtIn)) {
 					await this.writeFiles({
 						sections: entitySvelteFiles,
-						context: { ...application, ...entity, swaggerUi: this.swaggerUi, jest: this.jest },
+						context: {
+							...application,
+							...entity,
+							swaggerUi: this.swaggerUi,
+							jest: this.jest,
+							playwright: this.playwright,
+						},
 					});
 				}
 			},
@@ -297,6 +312,11 @@ export default class extends ClientGenerator {
 				});
 
 				const packageTemplate = JSON.parse(this.readTemplate('package.json'));
+				if (this.playwright) {
+					delete packageTemplate.devDependencies.cypress;
+					delete packageTemplate.devDependencies['eslint-plugin-cypress'];
+					packageTemplate.devDependencies['@playwright/test'] = '1.60.0';
+				}
 				this.packageJson.merge(packageTemplate);
 
 				if (this.swaggerUi) {

--- a/generators/client/templates/README.md.jhi.svelte.ejs
+++ b/generators/client/templates/README.md.jhi.svelte.ejs
@@ -86,10 +86,14 @@
  npm test
  ```
 
- UI end-to-end tests are powered by [Cypress][]. They're located under cypress directory and can be run by starting Spring Boot in one terminal (`./mvnw spring-boot:run`) and running the tests (`npm run e2e`) in a second one.
+ UI end-to-end tests are powered by <% if (playwright) { %>[Playwright][]<% } else { %>[Cypress][]<% } %>. They're located under <% if (playwright) { %>playwright<% } else { %>cypress<% } %> directory and can be run by starting Spring Boot in one terminal (`./mvnw spring-boot:run`) and running the tests (`npm run e2e`) in a second one.
 
  <&_ } -&>
  <&_ if (fragment.referenceSection) { -&>
  [Jest]: https://facebook.github.io/jest/
+<%_ if (playwright) { _%>
+ [Playwright]: https://playwright.dev/
+<%_ } else { _%>
  [Cypress]: https://www.cypress.io/
+<%_ } _%>
  <&_ } -&>

--- a/generators/client/templates/eslint.config.js.ejs
+++ b/generators/client/templates/eslint.config.js.ejs
@@ -1,5 +1,7 @@
 import svelte from "eslint-plugin-svelte";
+<%_ if (!playwright) { _%>
 import cypress from "eslint-plugin-cypress";
+<%_ } _%>
 import jestDom from "eslint-plugin-jest-dom";
 import globals from "globals";
 import path from "node:path";
@@ -29,12 +31,16 @@ export default [{
 }, ...compat.extends(
     "eslint:recommended",
     "plugin:svelte/recommended",
+<%_ if (!playwright) { _%>
     "plugin:cypress/recommended",
+<%_ } _%>
     "plugin:jest-dom/recommended",
 ), {
     plugins: {
         svelte,
+<%_ if (!playwright) { _%>
         cypress,
+<%_ } _%>
         "jest-dom": jestDom,
     },
 
@@ -42,7 +48,9 @@ export default [{
         globals: {
             ...globals.browser,
             ...globals.node,
+<%_ if (!playwright) { _%>
             ...cypress.environments.globals.globals,
+<%_ } _%>
 		<%_ if (this.blueprintConfig.jest) { _%>
 		"jest": true,
 		<%_ } else { _%>
@@ -58,4 +66,3 @@ export default [{
         "no-unused-vars": "off",
     },
 }];
-

--- a/generators/client/templates/package-template.json.ejs
+++ b/generators/client/templates/package-template.json.ejs
@@ -5,7 +5,7 @@
 	"private": true,
 	"license": "UNLICENSED",
 	"scripts": {
-		"format": "prettier --write \"{,src/**/,cypress/**/}*.{md,json,js,svelte,css,html,yml}\"",
+		"format": "prettier --write \"{,src/**/,<%= playwright ? 'playwright' : 'cypress' %>/**/}*.{md,json,js,svelte,css,html,yml}\"",
 		"lint": "eslint .",
 		"prepare": "husky",
 		"lint:fix": "npm run lint --fix",
@@ -15,8 +15,13 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
 		"e2e": "npm run e2e:ci -- --headed",
+<%_ if (playwright) { _%>
+		"e2e:ci": "playwright test",
+        "e2e:ui": "playwright test --ui",
+<%_ } else { _%>
 		"e2e:ci": "cypress run --browser chrome",
         "cy:open": "cypress open --e2e --browser chrome",
+<%_ } _%>
 		"build": "vite build",
 		"webapp:build": "npm run build",
 		"webapp:prod": "npm run build",

--- a/generators/client/templates/playwright.config.js.ejs
+++ b/generators/client/templates/playwright.config.js.ejs
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+	testDir: './playwright/e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	reporter: process.env.CI ? 'github' : 'list',
+	use: {
+		baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+		serviceWorkers: 'block',
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+	],
+})

--- a/generators/client/templates/playwright/e2e/account/register.spec.js.ejs
+++ b/generators/client/templates/playwright/e2e/account/register.spec.js.ejs
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test'
+import { byName } from '../../support/test-utils'
+
+test.describe('Register User', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/account/register')
+	})
+
+	test('greets with Create user title', async ({ page }) => {
+		await expect(page.getByTestId('registerTitle')).toBeVisible()
+		await expect(page.getByTestId('registerTitle')).toContainText('Create user account')
+	})
+
+	test('requires mandatory fields', async ({ page }) => {
+		await expect(page.getByTestId('registerForm').getByRole('button', { name: 'Create account' })).toBeDisabled()
+	})
+
+	test('requires username', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'username').fill('admin')
+		await byName(form, 'username').clear()
+		await byName(form, 'username').blur()
+		await expect(page.getByTestId('username-error')).toBeVisible()
+		await expect(page.getByTestId('username-error')).toContainText('Username is mandatory')
+	})
+
+	test('requires email', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'email').fill('admin@localhost.org')
+		await byName(form, 'email').clear()
+		await byName(form, 'email').blur()
+		await expect(page.getByTestId('email-error')).toBeVisible()
+		await expect(page.getByTestId('email-error')).toContainText('Email is mandatory')
+	})
+
+	test('requires valid email', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'email').fill('admin@localhost')
+		await byName(form, 'email').blur()
+		await expect(page.getByTestId('email-error')).toBeVisible()
+		await expect(page.getByTestId('email-error')).toContainText('Email address is not valid')
+	})
+
+	test('requires password', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'password').fill('password')
+		await byName(form, 'password').clear()
+		await byName(form, 'password').blur()
+		await expect(page.getByTestId('password-error')).toBeVisible()
+		await expect(page.getByTestId('password-error')).toContainText('Password is mandatory')
+	})
+
+	test('requires confirm password', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'passwordConfirm').fill('password')
+		await byName(form, 'passwordConfirm').clear()
+		await byName(form, 'passwordConfirm').blur()
+		await expect(page.getByTestId('passwordConfirm-error')).toBeVisible()
+		await expect(page.getByTestId('passwordConfirm-error')).toContainText('Password is mandatory')
+	})
+
+	test('requires password and confirm password to match', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'password').fill('abcd')
+		await byName(form, 'password').blur()
+		await byName(form, 'passwordConfirm').fill('defg')
+		await byName(form, 'passwordConfirm').blur()
+		await expect(page.getByTestId('passwordConfirm-error')).toBeVisible()
+		await expect(page.getByTestId('passwordConfirm-error')).toContainText('Password and its confirmation do not match')
+	})
+
+	test('does not allow user account creation with duplicate username', async ({ page }) => {
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'username').fill('admin')
+		await byName(form, 'email').fill('joe@localhost.org')
+		await byName(form, 'password').fill('jondoe')
+		await byName(form, 'passwordConfirm').fill('jondoe')
+		await expect(form.getByRole('button', { name: 'Create account' })).toBeEnabled()
+		await form.getByRole('button', { name: 'Create account' }).click()
+		await expect(page.getByTestId('errorMsg')).toContainText('Login name already in use. Please choose another one.')
+	})
+
+	test('creates a new user account', async ({ page }) => {
+		const uniqueLogin = `jon${Date.now()}`
+		const form = page.getByTestId('registerForm')
+		await byName(form, 'username').fill(uniqueLogin)
+		await byName(form, 'email').fill(`${uniqueLogin}@localhost.org`)
+		await byName(form, 'password').fill('jondoe')
+		await byName(form, 'passwordConfirm').fill('jondoe')
+		await expect(form.getByRole('button', { name: 'Create account' })).toBeEnabled()
+		await form.getByRole('button', { name: 'Create account' }).click()
+		await expect(page.getByTestId('successMsg')).toContainText('User account successfully created. Please check your email for confirmation.')
+		await expect(page.getByTestId('registerForm')).toHaveCount(0)
+	})
+})

--- a/generators/client/templates/playwright/e2e/home.spec.js.ejs
+++ b/generators/client/templates/playwright/e2e/home.spec.js.ejs
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+import { adminPassword, adminUsername, loginByApi } from '../support/test-utils'
+
+test.describe('Home page', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/')
+	})
+
+	test('greets with welcome title', async ({ page }) => {
+		await expect(page.getByTestId('welcomeTitle')).toBeVisible()
+		await expect(page.getByTestId('welcomeTitle')).toContainText('Welcome, JHipster Svelte!')
+	})
+
+	test.describe('unauthenticated user', () => {
+		test('has login instructions', async ({ page }) => {
+			await expect(page.getByTestId('loginInstructions')).toBeVisible()
+			await expect(page.getByTestId('loginInstructions')).toContainText('you can try the default accounts')
+			await expect(page.getByTestId('loginInstructions')).toContainText('Administrator (login="admin" and password="admin")')
+			await expect(page.getByTestId('loginInstructions')).toContainText('User (login="user" and password="user").')
+		})
+<%_ if (authenticationType !== 'oauth2' && !skipUserManagement) { _%>
+
+		test('has user registration link', async ({ page }) => {
+			await expect(page.getByTestId('svlRegisterHomeLink')).toBeVisible()
+			await expect(page.getByTestId('svlRegisterHomeLink')).toHaveAttribute('href', '/account/register')
+			await expect(page.getByTestId('svlRegisterHomeLink')).toContainText('Register a new account')
+		})
+<%_ } _%>
+	})
+<%_ if (authenticationType !== 'oauth2') { _%>
+
+	test.describe('authenticated user', () => {
+		test.beforeEach(async ({ page }) => {
+			await loginByApi(page, adminUsername, adminPassword)
+			await page.goto('/')
+		})
+
+		test('greets logged in user', async ({ page }) => {
+			await expect(page.getByTestId('greetMsg')).toBeVisible()
+			await expect(page.getByTestId('greetMsg')).toContainText(`You are logged in as user "${adminUsername}".`)
+		})
+	})
+<%_ } _%>
+})

--- a/generators/client/templates/playwright/e2e/login.spec.js.ejs
+++ b/generators/client/templates/playwright/e2e/login.spec.js.ejs
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test'
+import { byName } from '../support/test-utils'
+
+test.describe('User login', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/login')
+	})
+
+	test('greets with Sign in', async ({ page }) => {
+		await expect(page.getByTestId('signInTitle')).toBeVisible()
+		await expect(page.getByTestId('signInTitle')).toContainText('Sign in to <%= baseName %>')
+	})
+<%_ if (!skipUserManagement) { _%>
+
+	test('displays link to register', async ({ page }) => {
+		await expect(page.getByTestId('registerLink')).toHaveText('Create an account')
+		await expect(page.getByTestId('registerLink')).toHaveAttribute('href', '/account/register')
+	})
+
+	test('displays link to forgot password', async ({ page }) => {
+		await expect(page.getByTestId('forgotPwdLink')).toHaveText('Forgot password?')
+		await expect(page.getByTestId('forgotPwdLink')).toHaveAttribute('href', '/account/reset/init')
+	})
+<%_ } _%>
+
+	test('requires username and password', async ({ page }) => {
+		await expect(page.getByTestId('loginForm').getByRole('button', { name: 'Sign in' })).toBeDisabled()
+	})
+
+	test('requires username', async ({ page }) => {
+		const form = page.getByTestId('loginForm')
+		await byName(form, 'username').fill('admin')
+		await byName(form, 'username').clear()
+		await byName(form, 'username').blur()
+		await expect(page.getByTestId('username-error')).toBeVisible()
+		await expect(page.getByTestId('username-error')).toContainText('Username is mandatory')
+	})
+
+	test('requires password', async ({ page }) => {
+		const form = page.getByTestId('loginForm')
+		await byName(form, 'password').fill('admin')
+		await byName(form, 'password').clear()
+		await byName(form, 'password').blur()
+		await expect(page.getByTestId('password-error')).toBeVisible()
+		await expect(page.getByTestId('password-error')).toContainText('Password is mandatory')
+	})
+
+	test('requires a valid username and password', async ({ page }) => {
+		const form = page.getByTestId('loginForm')
+		await byName(form, 'username').fill('admin')
+		await byName(form, 'password').fill('invalid')
+		await byName(form, 'password').press('Enter')
+		await expect(page.getByTestId('errorMsg')).toContainText('Incorrect username or password.')
+	})
+
+	test('navigates to / on successful login', async ({ page }) => {
+		const form = page.getByTestId('loginForm')
+		await form.locator("input[type='checkbox']").first().check()
+		await byName(form, 'username').fill('admin')
+		await byName(form, 'password').fill('admin')
+		await byName(form, 'password').press('Enter')
+		await expect(page).toHaveURL('/')
+	})
+})

--- a/generators/client/templates/playwright/e2e/navbar.spec.js.ejs
+++ b/generators/client/templates/playwright/e2e/navbar.spec.js.ejs
@@ -1,0 +1,123 @@
+import { expect, test } from '@playwright/test'
+import { adminPassword, adminUsername, loginByApi, userPassword, userUsername } from '../support/test-utils'
+
+test.describe('Navbar', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/')
+	})
+
+	test.describe('unauthenticated user', () => {
+		test('displays application name', async ({ page }) => {
+			await expect(page.getByTestId('svlAppName')).toBeVisible()
+			await expect(page.getByTestId('svlAppName')).toContainText('<%= baseName %>')
+		})
+
+		test('displays application version', async ({ page }) => {
+			await expect(page.getByTestId('svlAppVersion')).toBeVisible()
+			await expect(page.getByTestId('svlAppVersion')).toContainText('DEV')
+		})
+
+		test('does not display navigation toggle button', async ({ page }) => {
+			await expect(page.getByTestId('svlNavBtn')).toBeHidden()
+		})
+
+		test('does not display account menu', async ({ page }) => {
+			await expect(page.getByTestId('svlAcctMenu')).toHaveCount(0)
+		})
+
+		test('displays sign in link', async ({ page }) => {
+			await expect(page.getByTestId('svlLoginLink')).toBeVisible()
+			await expect(page.getByTestId('svlLoginLink')).toContainText('Sign in')
+		})
+<%_ if (authenticationType !== 'oauth2' && !skipUserManagement) { _%>
+
+		test('displays register link', async ({ page }) => {
+			await expect(page.getByTestId('svlRegisterLink')).toBeVisible()
+			await expect(page.getByTestId('svlRegisterLink')).toContainText('Sign up')
+		})
+<%_ } _%>
+	})
+<%_ if (authenticationType !== 'oauth2') { _%>
+
+	test.describe('authenticated administrator', () => {
+		test.beforeEach(async ({ page }) => {
+			await loginByApi(page, adminUsername, adminPassword)
+			await page.goto('/')
+		})
+<%_ if (!skipUserManagement) { _%>
+
+		test('does not display register link', async ({ page }) => {
+			await expect(page.getByTestId('svlRegisterLink')).toHaveCount(0)
+		})
+<%_ } _%>
+
+		test('does not display sign in link', async ({ page }) => {
+			await expect(page.getByTestId('svlLoginLink')).toHaveCount(0)
+		})
+
+		test('displays account menu', async ({ page }) => {
+			await expect(page.getByTestId('svlAcctMenu')).toBeVisible()
+			await page.getByTestId('svlAccountLink').click()
+<%_ if (!skipUserManagement) { _%>
+			await expect(page.getByTestId('svlChgPwdLink')).toBeVisible()
+			await expect(page.getByTestId('svlChgPwdLink')).toHaveAttribute('href', '/account/password')
+			await expect(page.getByTestId('svlChgPwdLink')).toContainText('Change Password')
+			await expect(page.getByTestId('svlSettingsLink')).toBeVisible()
+			await expect(page.getByTestId('svlSettingsLink')).toHaveAttribute('href', '/account/settings')
+			await expect(page.getByTestId('svlSettingsLink')).toContainText('Settings')
+<%_ } _%>
+			await expect(page.getByTestId('svlSignoutLink')).toBeVisible()
+			await expect(page.getByTestId('svlSignoutLink')).toHaveAttribute('href', '/')
+			await expect(page.getByTestId('svlSignoutLink')).toContainText('Sign out')
+		})
+
+		test('displays administrator menu', async ({ page }) => {
+			await expect(page.getByTestId('svlAdminMenu')).toBeVisible()
+			await page.getByTestId('svlAdminLink').click()
+			await expect(page.getByTestId('svlLoggerLink')).toBeVisible()
+			await expect(page.getByTestId('svlLoggerLink')).toHaveAttribute('href', '/admin/logger')
+			await expect(page.getByTestId('svlLoggerLink')).toContainText('Loggers')
+<%_ if (!skipUserManagement) { _%>
+			await expect(page.getByTestId('svlUserMgmtLink')).toBeVisible()
+			await expect(page.getByTestId('svlUserMgmtLink')).toHaveAttribute('href', '/admin/user-management')
+			await expect(page.getByTestId('svlUserMgmtLink')).toContainText('User Management')
+<%_ } _%>
+		})
+<%_ if (!skipUserManagement) { _%>
+
+		test('navigates to change password page', async ({ page }) => {
+			await page.getByTestId('svlAccountLink').click()
+			await page.getByTestId('svlChgPwdLink').click()
+			await expect(page).toHaveURL('/account/password')
+		})
+
+		test('navigates to settings page', async ({ page }) => {
+			await page.getByTestId('svlAccountLink').click()
+			await page.getByTestId('svlSettingsLink').click()
+			await expect(page).toHaveURL('/account/settings')
+		})
+<%_ } _%>
+
+		test('logs out user', async ({ page }) => {
+			await page.getByTestId('svlAccountLink').click()
+			await page.getByTestId('svlSignoutLink').click()
+			await expect(page).toHaveURL('/')
+			await expect(page.getByTestId('svlLoginLink')).toBeVisible()
+			await expect(page.getByTestId('svlLoginLink')).toContainText('Sign in')
+		})
+	})
+<%_ if (!skipUserManagement) { _%>
+
+	test.describe('authenticated ROLE_USER user', () => {
+		test.beforeEach(async ({ page }) => {
+			await loginByApi(page, userUsername, userPassword)
+			await page.goto('/')
+		})
+
+		test('does not display administrator menu', async ({ page }) => {
+			await expect(page.getByTestId('svlAdminMenu')).toHaveCount(0)
+		})
+	})
+<%_ } _%>
+<%_ } _%>
+})

--- a/generators/client/templates/playwright/e2e/routes.spec.js.ejs
+++ b/generators/client/templates/playwright/e2e/routes.spec.js.ejs
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test'
+import { adminPassword, adminUsername, byName, loginByApi } from '../support/test-utils'
+
+test.describe('Routes', () => {
+	test.describe('unauthenticated user', () => {
+<%_ if (authenticationType !== 'oauth2' && !skipUserManagement) { _%>
+		test('does not allow navigation to settings page', async ({ page }) => {
+			await page.goto('/account/settings')
+			await expect(page).toHaveURL('/login')
+			await expect(page.getByTestId('signInTitle')).toBeVisible()
+			await expect(page.getByTestId('signInTitle')).toContainText('Sign in to <%= baseName %>')
+		})
+
+		test('does not allow navigation to user management page', async ({ page }) => {
+			await page.goto('/admin/user-management')
+			await expect(page).toHaveURL('/login')
+			await expect(page.getByTestId('signInTitle')).toBeVisible()
+			await expect(page.getByTestId('signInTitle')).toContainText('Sign in to <%= baseName %>')
+		})
+<%_ } _%>
+<%_ if (authenticationType !== 'oauth2') { _%>
+		test('does not allow navigation to Loggers page', async ({ page }) => {
+			await page.goto('/admin/logger')
+			await expect(page).toHaveURL('/login')
+			await expect(page.getByTestId('signInTitle')).toBeVisible()
+			await expect(page.getByTestId('signInTitle')).toContainText('Sign in to <%= baseName %>')
+		})
+<%_ } _%>
+
+		test('allows navigation to home page', async ({ page }) => {
+			await page.goto('/')
+			await expect(page).toHaveURL('/')
+			await expect(page.getByTestId('welcomeTitle')).toBeVisible()
+			await expect(page.getByTestId('welcomeTitle')).toContainText('Welcome, JHipster Svelte!')
+		})
+	})
+<%_ if (authenticationType !== 'oauth2') { _%>
+
+	test.describe('authenticated user', () => {
+		test.beforeEach(async ({ page }) => {
+			await loginByApi(page, adminUsername, adminPassword)
+		})
+
+		test('does not allow navigation to login page', async ({ page }) => {
+			await page.goto('/login')
+			await expect(page).toHaveURL('/')
+			await expect(page.getByTestId('welcomeTitle')).toBeVisible()
+			await expect(page.getByTestId('welcomeTitle')).toContainText('Welcome, JHipster Svelte!')
+		})
+<%_ if (!skipUserManagement) { _%>
+
+		test('does not allow navigation to register page', async ({ page }) => {
+			await page.goto('/account/register')
+			await expect(page).toHaveURL('/')
+			await expect(page.getByTestId('welcomeTitle')).toBeVisible()
+			await expect(page.getByTestId('welcomeTitle')).toContainText('Welcome, JHipster Svelte!')
+		})
+<%_ } _%>
+
+		test('allows navigation to home page', async ({ page }) => {
+			await page.goto('/')
+			await expect(page).toHaveURL('/')
+			await expect(page.getByTestId('welcomeTitle')).toBeVisible()
+			await expect(page.getByTestId('welcomeTitle')).toContainText('Welcome, JHipster Svelte!')
+		})
+	})
+
+	test.describe('navigation context', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/admin/logger')
+			await expect(page).toHaveURL('/login')
+		})
+
+		test('navigates to saved context', async ({ page }) => {
+			const form = page.getByTestId('loginForm')
+			await form.locator("input[type='checkbox']").first().check()
+			await byName(form, 'username').fill(adminUsername)
+			await byName(form, 'password').fill(adminPassword)
+			await byName(form, 'password').press('Enter')
+			await expect(page).toHaveURL('/admin/logger')
+			await expect(page.getByTestId('loggersTitle')).toBeVisible()
+			await expect(page.getByTestId('loggersTitle')).toContainText('Loggers')
+		})
+	})
+<%_ } _%>
+})

--- a/generators/client/templates/playwright/support/test-utils.js.ejs
+++ b/generators/client/templates/playwright/support/test-utils.js.ejs
@@ -1,0 +1,59 @@
+import { expect } from '@playwright/test'
+
+export const adminUsername = process.env.ADMIN_USERNAME ?? 'admin'
+export const adminPassword = process.env.ADMIN_PASSWORD ?? 'admin'
+export const userUsername = process.env.USER_USERNAME ?? 'user'
+export const userPassword = process.env.USER_PASSWORD ?? 'user'
+
+export const byName = (scope, name) => scope.locator(`[name="${name}"]`)
+
+export async function loginByApi(page, username = adminUsername, password = adminPassword) {
+<%_ if (authenticationType === 'session') { _%>
+	const csrfResponse = await page.request.get('/api/authenticate')
+	expect(csrfResponse.ok()).toBeTruthy()
+
+	const xsrfCookie = (await page.context().cookies()).find(cookie => cookie.name === 'XSRF-TOKEN')
+	expect(xsrfCookie?.value).toBeTruthy()
+
+	const loginResponse = await page.request.post('/api/authentication', {
+		form: {
+			username,
+			password,
+			'remember-me': 'true',
+		},
+		headers: {
+			'X-XSRF-TOKEN': xsrfCookie.value,
+		},
+	})
+	expect(loginResponse.ok()).toBeTruthy()
+<%_ } else if (authenticationType === 'jwt') { _%>
+	const loginResponse = await page.request.post('/api/authenticate', {
+		data: {
+			username,
+			password,
+			'remember-me': false,
+		},
+	})
+	expect(loginResponse.ok()).toBeTruthy()
+
+	const { id_token: token } = await loginResponse.json()
+	expect(token).toBeTruthy()
+
+	await page.addInitScript(authToken => {
+		window.localStorage.setItem('authToken', authToken)
+	}, token)
+	await page.goto('/')
+	await page.evaluate(authToken => {
+		window.localStorage.setItem('authToken', authToken)
+	}, token)
+<%_ } else { _%>
+	throw new Error('Playwright API login is not configured for OAuth2 authentication yet.')
+<%_ } _%>
+
+	const accountResponse = await page.request.get('/api/account'<% if (authenticationType === 'jwt') { %>, {
+		headers: {
+			Authorization: `Bearer ${await page.evaluate(() => window.localStorage.getItem('authToken'))}`,
+		},
+	}<% } %>)
+	expect(accountResponse.ok()).toBeTruthy()
+}

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -159,7 +159,7 @@ security:
 
 Create an OIDC App in Okta to get a `{clientId}` and `{clientSecret}`. To do this, log in to your Okta Developer account and navigate to **Applications** > **Add Application**. Click **Web** and click the **Next** button. Give the app a name you’ll remember, specify `http://localhost:8080` as a Base URI, and `http://localhost:8080/login/oauth2/code/oidc` as a Login Redirect URI. Click **Done**, then Edit and add `http://localhost:8080` as a Logout redirect URI. Copy and paste the client ID and secret into your `application.yml` file.
 
-Create a `ROLE_ADMIN` and `ROLE_USER` group and add users into them. Modify e2e tests to use this account when running integration tests. You'll need to change Cypress environment credentials in `cypress.json` or override defaults with OS [environment variables](https://docs.cypress.io/guides/guides/environment-variables#Setting).
+Create a `ROLE_ADMIN` and `ROLE_USER` group and add users into them. Modify e2e tests to use this account when running integration tests. <% if (this.blueprintConfig.playwright) { %>Override the default Playwright credentials with the `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `USER_USERNAME`, and `USER_PASSWORD` environment variables.<% } else { %>You'll need to change Cypress environment credentials in `cypress.json` or override defaults with OS [environment variables](https://docs.cypress.io/guides/guides/environment-variables#Setting).<% } %>
 
 Navigate to **API** > **Authorization Servers**, click the **Authorization Servers** tab and edit the default one. Click the **Claims** tab and **Add Claim**. Name it "groups", and include it in the ID Token. Set the value type to "Groups" and set the filter to be a Regex of `.*`.
 
@@ -245,7 +245,7 @@ Unit tests are run by <% if (this.blueprintConfig.jest) { %>[Jest][]<% } %>. The
 ```
 <%= clientPackageManager %> test
 ```
-UI end-to-end tests are powered by [Cypress][]. They're located under cypress directory and can be run by starting Spring Boot in one terminal (`<% if (buildToolMaven) { %>./mvnw spring-boot:run<% } else { %>./gradlew bootRun<% } %>`) and running the tests (`<%= clientPackageManager %> run e2e`) in a second one.
+UI end-to-end tests are powered by <% if (this.blueprintConfig.playwright) { %>[Playwright][]<% } else { %>[Cypress][]<% } %>. They're located under <% if (this.blueprintConfig.playwright) { %>playwright<% } else { %>cypress<% } %> directory and can be run by starting Spring Boot in one terminal (`<% if (buildToolMaven) { %>./mvnw spring-boot:run<% } else { %>./gradlew bootRun<% } %>`) and running the tests (`<%= clientPackageManager %> run e2e`) in a second one.
 
 <%_ if (gatlingTests) { _%>
 ### Other tests
@@ -327,7 +327,11 @@ To configure CI for your project, run the ci-cd sub-generator (`jhipster ci-cd`)
 <%_ if (this.blueprintConfig.jest) { _%>
 [Jest]: https://facebook.github.io/jest/
 <%_ } _%>
+<%_ if (this.blueprintConfig.playwright) { _%>
+[Playwright]: https://playwright.dev/
+<%_ } else { _%>
 [Cypress]: https://www.cypress.io/
+<%_ } _%>
 <%_ if (enableSwaggerCodegen) { _%>
 [OpenAPI-Generator]: https://openapi-generator.tech
 [Swagger-Editor]: https://editor.swagger.io

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"sveltekit",
 		"tailwindcss",
 		"cypress",
+		"playwright",
 		"vite"
 	],
 	"homepage": "https://github.com/jhipster/generator-jhipster-svelte",


### PR DESCRIPTION
Closes #1650.

## Summary

- Adds a blueprint-scoped `--playwright` option that generates Playwright E2E support instead of Cypress.
- Generates Playwright config, shared test helpers, and starter specs for home, navbar, routes, login, and registration flows.
- Keeps Cypress as the default path and avoids Cypress dependencies/config/tests when Playwright is selected.
- Updates generated package scripts, ESLint config, and README text for the selected E2E framework.

## Verification

- `npm run lint`
- `./node_modules/.bin/ejslint generators/**/*.ejs`
- Generated a JWT sample app with `--playwright --skip-install --skip-git --skip-checks --no-insight`; verified generated package/README/ESLint reference Playwright and no Cypress.
- Generated a default JWT sample app without `--playwright`; verified Cypress remains the default.
- Ran `node --check` on the generated Playwright config, shared helper, and generated Playwright specs.
