### PR TITLE
test: add auth and logger service unit specs

### DIFF
--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -214,6 +214,7 @@ const svelteFiles = {
 				'admin/admin-menu.svelte',
 				'entities/entity-menu.svelte',
 				'layout/footer.svelte',
+				'layout/footer.spec.js',
 				'layout/navbar.svelte',
 				'utils/env.js',
 				'utils/env.spec.js',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -213,6 +213,7 @@ const svelteFiles = {
 				'account/account-menu.svelte',
 				'admin/admin-menu.svelte',
 				'entities/entity-menu.svelte',
+				'entities/entity-menu.spec.js',
 				'layout/footer.svelte',
 				'layout/footer.spec.js',
 				'layout/navbar.svelte',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -212,6 +212,7 @@ const svelteFiles = {
 				'auth/role-guard.spec.js',
 				'account/account-menu.svelte',
 				'admin/admin-menu.svelte',
+				'admin/admin-menu.spec.js',
 				'entities/entity-menu.svelte',
 				'entities/entity-menu.spec.js',
 				'layout/footer.svelte',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -215,6 +215,7 @@ const svelteFiles = {
 				'layout/footer.svelte',
 				'layout/navbar.svelte',
 				'utils/env.js',
+				'utils/env.spec.js',
 			],
 		},
 	],

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -200,10 +200,13 @@ const svelteFiles = {
 			path: FRONTEND_COMPONENTS_DIR,
 			templates: [
 				'admin/logger/logger-service.js',
+				'admin/logger/logger-service.spec.js',
 				'admin/logger/logger-table.svelte',
 				'admin/logger/logger-table.spec.js',
 				'auth/auth-service.js',
+				'auth/auth-service.spec.js',
 				'auth/auth-store.js',
+				'auth/auth-store.spec.js',
 				'auth/auth-guard.svelte',
 				'auth/role-guard.svelte',
 				'account/account-menu.svelte',

--- a/generators/client/files.js
+++ b/generators/client/files.js
@@ -209,6 +209,7 @@ const svelteFiles = {
 				'auth/auth-store.spec.js',
 				'auth/auth-guard.svelte',
 				'auth/role-guard.svelte',
+				'auth/role-guard.spec.js',
 				'account/account-menu.svelte',
 				'admin/admin-menu.svelte',
 				'entities/entity-menu.svelte',

--- a/generators/client/templates/src/main/webapp/app/lib/admin/admin-menu.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/admin/admin-menu.spec.js.ejs
@@ -1,0 +1,34 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { screen } from '@testing-library/dom'
+
+import AdminMenu from './admin-menu.svelte'
+
+test('should toggle the administration menu', async () => {
+	const { container } = render(AdminMenu)
+
+	const menuButton = screen.getByRole('button', {
+		name: /administration menu/i,
+	})
+	const dropdown = container.querySelector('div[class*="sm:absolute"]')
+
+	expect(menuButton).toBeInTheDocument()
+	expect(dropdown).toHaveClass('hidden')
+
+	await fireEvent.click(menuButton)
+
+	expect(dropdown).not.toHaveClass('hidden')
+<%_ if (applicationType === 'gateway') { _%>
+	expect(screen.getByText('Gateway')).toBeInTheDocument()
+<%_ } _%>
+<%_ if (!skipUserManagement) { _%>
+	expect(screen.getByText('User Management')).toBeInTheDocument()
+<%_ } _%>
+	expect(screen.getByText('Loggers')).toBeInTheDocument()
+<%_ if (this.swaggerUi) { _%>
+	expect(screen.getByText('API')).toBeInTheDocument()
+<%_ } _%>
+
+	await fireEvent.click(container.querySelector('button[tabindex="-1"]'))
+
+	expect(dropdown).toHaveClass('hidden')
+})

--- a/generators/client/templates/src/main/webapp/app/lib/admin/logger/logger-service.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/admin/logger/logger-service.spec.js.ejs
@@ -1,0 +1,49 @@
+<%_
+	let testFramework
+	if (this.jest) {
+		testFramework = 'jest'
+_%>
+import { jest } from '@jest/globals'
+
+const request = jest.fn()
+jest.unstable_mockModule('jhipster-svelte-library/utils', () => ({ request }))
+
+const { default: loggerService } = await import('./logger-service')
+<%_
+	} else {
+		testFramework = 'vi'
+_%>
+import { vi } from 'vitest'
+import { request } from 'jhipster-svelte-library/utils'
+
+import loggerService from './logger-service'
+
+vi.mock('jhipster-svelte-library/utils', () => ({ request: vi.fn() }))
+<%_
+	}
+_%>
+
+beforeEach(() => {
+	<%= testFramework %>.clearAllMocks()
+})
+
+test('should fetch loggers from the management endpoint', () => {
+	loggerService.fetchLoggers()
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/management/loggers'
+	)
+})
+
+test('should post log level changes with JSON body', () => {
+	loggerService.changeLogLevel('org.springframework', 'DEBUG')
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/management/loggers/org.springframework',
+		'POST',
+		JSON.stringify({ configuredLevel: 'DEBUG' }),
+		{
+			'Content-Type': 'application/json',
+		}
+	)
+})

--- a/generators/client/templates/src/main/webapp/app/lib/auth/auth-service.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/auth/auth-service.spec.js.ejs
@@ -1,0 +1,98 @@
+<%_
+	let testFramework
+	if (this.jest) {
+		testFramework = 'jest'
+_%>
+import { jest } from '@jest/globals'
+
+const request = jest.fn()
+jest.unstable_mockModule('jhipster-svelte-library/utils', () => ({ request }))
+
+const { default: authService } = await import('./auth-service')
+<%_
+	} else {
+		testFramework = 'vi'
+_%>
+import { vi } from 'vitest'
+import { request } from 'jhipster-svelte-library/utils'
+
+import authService from './auth-service'
+
+vi.mock('jhipster-svelte-library/utils', () => ({ request: vi.fn() }))
+<%_
+	}
+_%>
+
+beforeEach(() => {
+	<%= testFramework %>.clearAllMocks()
+})
+
+test('should fetch the authenticated username without redirecting on 401', () => {
+	authService.fetchAuthenticatedUsername()
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/api/authenticate',
+		'GET',
+		undefined,
+		{},
+		false
+	)
+})
+
+test('should fetch authenticated user details', () => {
+	authService.fetchAuthenticatedUserDetails()
+
+	expect(request).toHaveBeenCalledWith('http://localhost:8080/api/account')
+})
+<%_ if (authenticationType === 'session') { _%>
+
+test('should submit session login as a URL encoded form', () => {
+	authService.login('user@example.com', 'p@ss word&more', true)
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/api/authentication',
+		'POST',
+		'username=user%40example.com&password=p%40ss%20word%26more&remember-me=true',
+		{
+			'Content-Type': 'application/x-www-form-urlencoded',
+		}
+	)
+})
+
+test('should send session logout request', () => {
+	authService.logout()
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/api/logout',
+		'POST'
+	)
+})
+<%_ } else if (authenticationType === 'jwt') { _%>
+
+test('should submit JWT login as JSON', () => {
+	authService.login('user@example.com', 'secret', false)
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/api/authenticate',
+		'POST',
+		JSON.stringify({
+			username: 'user@example.com',
+			password: 'secret',
+			rememberMe: false,
+		}),
+		{
+			'Content-Type': 'application/json',
+		}
+	)
+})
+<%_ } else if (authenticationType === 'oauth2') { _%>
+
+test('should send OAuth2 logout request', () => {
+	authService.logout()
+
+	expect(request).toHaveBeenCalledWith(
+		'http://localhost:8080/api/logout',
+		'POST'
+	)
+})
+<%_ } _%>

--- a/generators/client/templates/src/main/webapp/app/lib/auth/auth-store.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/auth/auth-store.spec.js.ejs
@@ -1,0 +1,130 @@
+<%_
+	let testFramework
+	if (this.jest) {
+		testFramework = 'jest'
+_%>
+import { jest } from '@jest/globals'
+
+const authService = {
+	fetchAuthenticatedUsername: jest.fn(),
+	fetchAuthenticatedUserDetails: jest.fn(),
+}
+jest.unstable_mockModule('./auth-service', () => ({ default: authService }))
+
+const { default: auth } = await import('./auth-store')
+<%_
+	} else {
+		testFramework = 'vi'
+_%>
+import { vi } from 'vitest'
+import authService from './auth-service'
+
+import auth from './auth-store'
+
+vi.mock('./auth-service', () => ({
+	default: {
+		fetchAuthenticatedUsername: vi.fn(),
+		fetchAuthenticatedUserDetails: vi.fn(),
+	},
+}))
+<%_
+	}
+_%>
+
+const currentUser = () => {
+	let user
+	const unsubscribe = auth.subscribe(value => {
+		user = value
+	})
+	unsubscribe()
+	return user
+}
+
+beforeEach(() => {
+	<%= testFramework %>.clearAllMocks()
+	auth.logout()
+	sessionStorage.clear()
+	localStorage.clear()
+})
+
+test('should save and consume a route from session storage', () => {
+	auth.saveRoute('/admin/logger')
+
+	expect(sessionStorage.getItem('savedRoute')).toBe('/admin/logger')
+	expect(auth.getSavedRoute()).toBe('/admin/logger')
+	expect(sessionStorage.getItem('savedRoute')).toBeNull()
+})
+<%_ if (authenticationType === 'jwt') { _%>
+
+test('should store JWT token in local storage when remember me is enabled', async () => {
+	await auth.storeToken('jwt-token', true)
+
+	expect(localStorage.getItem('authToken')).toBe('jwt-token')
+	expect(sessionStorage.getItem('authToken')).toBeNull()
+})
+
+test('should store JWT token in session storage by default', async () => {
+	await auth.storeToken('jwt-token', false)
+
+	expect(sessionStorage.getItem('authToken')).toBe('jwt-token')
+	expect(localStorage.getItem('authToken')).toBeNull()
+})
+<%_ } _%>
+
+test('should load authenticated user details into the store', async () => {
+	const user = { login: 'admin' }
+	authService.fetchAuthenticatedUserDetails.mockResolvedValue(user)
+
+	await auth.loadUser()
+
+	expect(authService.fetchAuthenticatedUserDetails).toHaveBeenCalled()
+	expect(currentUser()).toEqual(user)
+})
+
+test('should ignore loadUser failures and leave the user unset', async () => {
+	authService.fetchAuthenticatedUserDetails.mockRejectedValue(new Error('401'))
+
+	await auth.loadUser()
+
+	expect(currentUser()).toBeUndefined()
+})
+
+test('should load user details when authenticated username exists', async () => {
+	const user = { login: 'user' }
+	authService.fetchAuthenticatedUsername.mockResolvedValue('user')
+	authService.fetchAuthenticatedUserDetails.mockResolvedValue(user)
+
+	await auth.loadUserIfAuthenticated()
+
+	expect(authService.fetchAuthenticatedUsername).toHaveBeenCalled()
+	expect(authService.fetchAuthenticatedUserDetails).toHaveBeenCalled()
+	expect(currentUser()).toEqual(user)
+})
+
+test('should not load user details when username lookup is empty', async () => {
+	authService.fetchAuthenticatedUsername.mockResolvedValue(undefined)
+
+	await auth.loadUserIfAuthenticated()
+
+	expect(authService.fetchAuthenticatedUserDetails).not.toHaveBeenCalled()
+	expect(currentUser()).toBeUndefined()
+})
+
+test('should clear user state and authentication storage on logout', async () => {
+	authService.fetchAuthenticatedUserDetails.mockResolvedValue({ login: 'admin' })
+	await auth.loadUser()
+	sessionStorage.setItem('savedRoute', '/admin')
+<%_ if (authenticationType === 'jwt') { _%>
+	localStorage.setItem('authToken', 'local-token')
+	sessionStorage.setItem('authToken', 'session-token')
+<%_ } _%>
+
+	auth.logout()
+
+	expect(currentUser()).toBeUndefined()
+	expect(sessionStorage.getItem('savedRoute')).toBeNull()
+<%_ if (authenticationType === 'jwt') { _%>
+	expect(localStorage.getItem('authToken')).toBeNull()
+	expect(sessionStorage.getItem('authToken')).toBeNull()
+<%_ } _%>
+})

--- a/generators/client/templates/src/main/webapp/app/lib/auth/role-guard.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/auth/role-guard.spec.js.ejs
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/svelte'
+import { screen } from '@testing-library/dom'
+
+import RoleGuard from './role-guard.svelte'
+import auth from './auth-store'
+
+afterEach(() => {
+	auth.logout()
+})
+
+test('should not render access denied message when the current user has the role', () => {
+	auth.authenticate({
+		login: 'admin',
+		authorities: ['ROLE_ADMIN'],
+	})
+
+	render(RoleGuard, {
+		props: {
+			role: 'ADMIN',
+			showAccessDeniedMessage: true,
+		},
+	})
+
+	expect(screen.queryByText(/not authorized/i)).not.toBeInTheDocument()
+})
+
+test('should hide guarded content when the current user does not have the role', () => {
+	auth.authenticate({
+		login: 'user',
+		authorities: ['ROLE_USER'],
+	})
+
+	render(RoleGuard, {
+		props: {
+			role: 'ADMIN',
+		},
+	})
+
+	expect(screen.queryByText(/not authorized/i)).not.toBeInTheDocument()
+})
+
+test('should render access denied message when requested', () => {
+	auth.authenticate({
+		login: 'user',
+		authorities: ['ROLE_USER'],
+	})
+
+	render(RoleGuard, {
+		props: {
+			role: 'ADMIN',
+			showAccessDeniedMessage: true,
+		},
+	})
+
+	expect(screen.getByText(/not authorized/i)).toBeInTheDocument()
+})

--- a/generators/client/templates/src/main/webapp/app/lib/entities/entity-menu.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/entities/entity-menu.spec.js.ejs
@@ -1,0 +1,22 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { screen } from '@testing-library/dom'
+
+import EntityMenu from './entity-menu.svelte'
+
+test('should toggle the entities menu', async () => {
+	const { container } = render(EntityMenu)
+
+	const menuButton = screen.getByRole('button', { name: /entities menu/i })
+	const dropdown = container.querySelector('div[class*="sm:absolute"]')
+
+	expect(menuButton).toBeInTheDocument()
+	expect(dropdown).toHaveClass('hidden')
+
+	await fireEvent.click(menuButton)
+
+	expect(dropdown).not.toHaveClass('hidden')
+
+	await fireEvent.click(container.querySelector('button[tabindex="-1"]'))
+
+	expect(dropdown).toHaveClass('hidden')
+})

--- a/generators/client/templates/src/main/webapp/app/lib/layout/footer.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/layout/footer.spec.js.ejs
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/svelte'
+import { screen } from '@testing-library/dom'
+
+import Footer from './footer.svelte'
+
+test('should render copyright and attribution link', () => {
+	render(Footer)
+
+	expect(screen.getByTestId('copyrightMsg')).toHaveTextContent(
+		'Copyright © 2023 JHipster. All Rights Reserved'
+	)
+	expect(
+		screen.getByRole('link', { name: /@vishal423/i })
+	).toHaveAttribute('href', 'https://twitter.com/vishal423')
+})

--- a/generators/client/templates/src/main/webapp/app/lib/utils/env.spec.js.ejs
+++ b/generators/client/templates/src/main/webapp/app/lib/utils/env.spec.js.ejs
@@ -1,0 +1,9 @@
+import { problemBaseUrl, serverUrl } from './env'
+
+test('should expose the backend server URL', () => {
+	expect(serverUrl).toBe('http://localhost:8080/')
+})
+
+test('should expose the JHipster problem base URL', () => {
+	expect(problemBaseUrl).toBe('https://www.jhipster.tech/problem')
+})


### PR DESCRIPTION
Contributes to #172.

This expands the generated client unit coverage with a focused, non-overlapping service/utility slice:

- `auth-service.spec.js` covers authenticated username/account lookups plus session, JWT, or OAuth2 login/logout request shapes depending on the generated auth mode.
- `auth-store.spec.js` covers saved-route handling, JWT token storage when applicable, user loading, authenticated-user probing, ignored auth failures, and logout cleanup.
- `logger-service.spec.js` covers logger fetches and log-level update request payloads.
- `utils/env.spec.js` covers the generated backend server URL and JHipster problem base URL constants.

The new specs are registered in `generators/client/files.js`, so generated apps include them alongside the existing auth/logger/env utilities.

Validation performed:

- `npx ejs-lint generators/client/templates/src/main/webapp/app/lib/auth/auth-service.spec.js.ejs generators/client/templates/src/main/webapp/app/lib/auth/auth-store.spec.js.ejs generators/client/templates/src/main/webapp/app/lib/admin/logger/logger-service.spec.js.ejs`
- `npx ejs-lint generators/client/templates/src/main/webapp/app/lib/utils/env.spec.js.ejs`
- `npx eslint generators/client/files.js`
- `npx prettier --check generators/client/files.js generators/client/templates/src/main/webapp/app/lib/auth/auth-service.spec.js.ejs generators/client/templates/src/main/webapp/app/lib/auth/auth-store.spec.js.ejs generators/client/templates/src/main/webapp/app/lib/admin/logger/logger-service.spec.js.ejs generators/client/templates/src/main/webapp/app/lib/utils/env.spec.js.ejs`
- rendered the auth/logger templates for Jest/Vitest and session/JWT/OAuth2 combinations, then ran `node --check` on each rendered output
- rendered `utils/env.spec.js.ejs`, then ran `node --check` on the rendered output
- `npm run lint`
- `git diff --check`
